### PR TITLE
Implemented drawing canvas with particle effects.

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -4,7 +4,7 @@
     <selectionStates>
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
-        <DropdownSelection timestamp="2025-09-17T21:20:51.750118Z">
+        <DropdownSelection timestamp="2025-09-18T01:41:23.123481Z">
           <Target type="DEFAULT_BOOT">
             <handle>
               <DeviceId pluginId="LocalEmulator" identifier="path=/Users/stoyan/.android/avd/Pixel_7_Pro.avd" />

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/core/ui/DrawingController.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/core/ui/DrawingController.kt
@@ -1,0 +1,169 @@
+package com.stoyanvuchev.magicmessage.core.ui
+
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshots.SnapshotStateList
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import com.stoyanvuchev.magicmessage.core.ui.utils.ParticleUtils
+import com.stoyanvuchev.magicmessage.domain.BrushType
+import com.stoyanvuchev.magicmessage.domain.model.Particle
+import com.stoyanvuchev.magicmessage.domain.model.StrokeModel
+import com.stoyanvuchev.magicmessage.domain.model.TimedPoint
+
+@Stable
+class DrawingController {
+
+    // Max allowed points per session
+    val maxPoints: Int = 500
+    var totalPointCount by mutableIntStateOf(0)
+        private set
+
+    var drawingEnabled by mutableStateOf(true)
+        private set
+
+    val strokes = mutableStateListOf<StrokeModel>()
+
+    private val _particles = mutableListOf<Particle>()
+    val particles: SnapshotStateList<Particle> = mutableStateListOf()
+
+    val currentPoints = mutableStateListOf<TimedPoint>()
+
+    private val undoStack = ArrayDeque<StrokeModel>()
+    private val redoStack = ArrayDeque<StrokeModel>()
+
+    private var startTime: Long = 0
+    private val lock = Any()
+
+    fun startStroke(
+        offset: Offset,
+        color: Color
+    ) {
+        if (!drawingEnabled) return
+        currentPoints.clear()
+        startTime = System.currentTimeMillis()
+        currentPoints.add(TimedPoint(offset, 0L))
+        spawnParticles(offset, color)
+    }
+
+    fun addPoint(
+        offset: Offset,
+        color: Color
+    ) {
+
+        if (!drawingEnabled) return
+
+        // Check if adding this point exceeds the max
+        val prospectiveTotal = totalPointCount + currentPoints.size + 1
+        if (prospectiveTotal > maxPoints) {
+            drawingEnabled = false
+            return
+        }
+
+        val t = System.currentTimeMillis() - startTime
+        val point = TimedPoint(offset, t)
+        currentPoints.add(point)
+        spawnParticles(offset, color)
+
+    }
+
+    fun endStroke(
+        color: Color,
+        width: Float,
+        brush: BrushType
+    ) {
+        if (currentPoints.isNotEmpty()) {
+
+            val stroke = StrokeModel(
+                points = currentPoints.toList(),
+                color = color,
+                width = width,
+                brush = brush
+            )
+
+            strokes.add(stroke)
+            undoStack.addLast(stroke)
+            redoStack.clear()
+
+            totalPointCount += stroke.points.size
+            if (totalPointCount >= maxPoints) {
+                drawingEnabled = false
+            }
+
+            currentPoints.clear()
+
+        }
+    }
+
+    private fun spawnParticles(
+        offset: Offset,
+        color: Color
+    ) {
+        synchronized(lock) {
+            _particles.addAll(
+                ParticleUtils.spawnParticles(
+                    at = offset,
+                    brushColor = color
+                )
+            )
+        }
+    }
+
+    fun updateParticles(deltaMs: Long) {
+        synchronized(lock) {
+            val iterator = _particles.iterator()
+            while (iterator.hasNext()) {
+                val p = iterator.next()
+                p.position += p.velocity * (deltaMs / 16f)
+                p.age += deltaMs
+                if (p.age >= p.lifetime) iterator.remove() // safe removal
+            }
+        }
+    }
+
+    fun syncParticlesToUI() {
+        particles.clear()
+        particles.addAll(_particles)
+    }
+
+    fun clear() {
+        strokes.clear()
+        _particles.clear()
+        currentPoints.clear()
+        undoStack.clear()
+        redoStack.clear()
+        totalPointCount = 0
+        drawingEnabled = true
+    }
+
+    fun undo() {
+
+        val last = undoStack.removeLastOrNull() ?: return
+        strokes.remove(last)
+        redoStack.addLast(last)
+
+        totalPointCount -= last.points.size
+        if (!drawingEnabled && totalPointCount < maxPoints) {
+            drawingEnabled = true
+        }
+
+    }
+
+    fun redo() {
+
+        val last = redoStack.removeLastOrNull() ?: return
+        strokes.add(last)
+        undoStack.addLast(last)
+
+        totalPointCount += last.points.size
+        if (totalPointCount >= maxPoints) {
+            drawingEnabled = false
+        }
+
+    }
+
+}

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/core/ui/ParticleUpdater.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/core/ui/ParticleUpdater.kt
@@ -1,0 +1,36 @@
+package com.stoyanvuchev.magicmessage.core.ui
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.withContext
+
+@Composable
+fun ParticleUpdater(controller: DrawingController) {
+    LaunchedEffect(Unit) {
+        withContext(Dispatchers.Default) {
+
+            var lastTime = System.currentTimeMillis()
+            while (isActive) {
+
+                val now = System.currentTimeMillis()
+                val delta = now - lastTime
+                lastTime = now
+
+                // Update physics off UI thread.
+                controller.updateParticles(delta)
+
+                // Sync to Compose state on Main thread.
+                withContext(Dispatchers.Main) {
+                    controller.syncParticlesToUI()
+                }
+
+                delay(16L) // ~60fps
+
+            }
+
+        }
+    }
+}

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/core/ui/components/DrawingCanvas.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/core/ui/components/DrawingCanvas.kt
@@ -1,0 +1,88 @@
+package com.stoyanvuchev.magicmessage.core.ui.components
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.foundation.gestures.drag
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clipToBounds
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.stoyanvuchev.magicmessage.core.ui.DrawingController
+import com.stoyanvuchev.magicmessage.core.ui.ParticleUpdater
+import com.stoyanvuchev.magicmessage.core.ui.ext.drawStroke
+import com.stoyanvuchev.magicmessage.domain.BrushType
+import com.stoyanvuchev.magicmessage.domain.model.StrokeModel
+
+@Composable
+fun DrawingCanvas(
+    modifier: Modifier = Modifier,
+    controller: DrawingController,
+    color: Color = MaterialTheme.colorScheme.primary,
+    width: Dp = 5.dp
+) {
+
+    ParticleUpdater(controller = controller)
+
+    Canvas(
+        modifier = modifier
+            .clipToBounds()
+            .pointerInput(Unit) {
+                if (!controller.drawingEnabled) return@pointerInput
+                awaitEachGesture {
+
+                    val down = awaitFirstDown()
+                    controller.startStroke(
+                        offset = down.position,
+                        color = color
+                    )
+
+                    drag(down.id) { change ->
+                        controller.addPoint(
+                            change.position,
+                            color = color
+                        )
+                        change.consume()
+                    }
+
+                    controller.endStroke(
+                        color = color,
+                        width = width.toPx(),
+                        brush = BrushType.NORMAL
+                    )
+
+                }
+            }
+    ) {
+
+        // Draw completed strokes.
+        controller.strokes.forEach { drawStroke(it) }
+
+        // Draw the current stroke in real-time.
+        if (controller.currentPoints.isNotEmpty()) {
+            drawStroke(
+                StrokeModel(
+                    points = controller.currentPoints.toList(),
+                    color = color,
+                    width = width.toPx(),
+                    brush = BrushType.GLOW
+                )
+            )
+        }
+
+        // Draw particles.
+        controller.particles.forEach { particle ->
+            drawCircle(
+                color = particle.color,
+                radius = particle.size,
+                center = particle.position
+            )
+        }
+
+    }
+
+}

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/core/ui/ext/DrawScopeExt.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/core/ui/ext/DrawScopeExt.kt
@@ -1,0 +1,106 @@
+package com.stoyanvuchev.magicmessage.core.ui.ext
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.StrokeJoin
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.drawscope.Stroke
+import com.stoyanvuchev.magicmessage.domain.BrushType
+import com.stoyanvuchev.magicmessage.domain.model.StrokeModel
+
+fun DrawScope.drawStroke(stroke: StrokeModel) {
+
+    // Single tap: draw a circle instead of a path.
+    if (stroke.points.size == 1) {
+
+        if (stroke.brush == BrushType.GLOW) {
+
+            drawCircle(
+                color = stroke.color.copy(alpha = .25f),
+                radius = stroke.width * 1.5f,
+                center = stroke.points.first().offset
+            )
+
+            drawCircle(
+                color = stroke.color.copy(alpha = .25f),
+                radius = stroke.width,
+                center = stroke.points.first().offset
+            )
+
+        }
+
+        drawCircle(
+            color = stroke.color,
+            radius = stroke.width / 2f,
+            center = stroke.points.first().offset
+        )
+
+        return
+
+    }
+
+    val path = stroke.points.map { it.offset }.toSmoothPath()
+    when (stroke.brush) {
+
+        BrushType.NORMAL -> {
+            drawPath(
+                path = path,
+                color = stroke.color,
+                style = Stroke(
+                    width = stroke.width,
+                    cap = StrokeCap.Round,
+                    join = StrokeJoin.Round
+                )
+            )
+        }
+
+        BrushType.GLOW -> {
+            drawGlowPath(
+                path = path,
+                color = stroke.color,
+                width = stroke.width
+            )
+        }
+
+    }
+
+}
+
+fun DrawScope.drawGlowPath(
+    path: Path,
+    color: Color,
+    width: Float
+) {
+
+    drawPath(
+        path = path,
+        color = color.copy(alpha = .25f),
+        style = Stroke(
+            width = width * 3f,
+            cap = StrokeCap.Round,
+            join = StrokeJoin.Round
+        )
+    )
+
+    drawPath(
+        path = path,
+        color = color.copy(alpha = .25f),
+        style = Stroke(
+            width = width * 2f,
+            cap = StrokeCap.Round,
+            join = StrokeJoin.Round
+        )
+    )
+
+    drawPath(
+        path = path,
+        color = color,
+        style = Stroke(
+            width = width,
+            cap = StrokeCap.Round,
+            join = StrokeJoin.Round
+        )
+    )
+
+}

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/core/ui/ext/ListExt.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/core/ui/ext/ListExt.kt
@@ -1,0 +1,42 @@
+package com.stoyanvuchev.magicmessage.core.ui.ext
+
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Path
+
+fun List<Offset>.toSmoothPath(): Path {
+
+    val path = Path()
+    if (isEmpty()) return path
+
+    path.moveTo(
+        x = first().x,
+        y = first().y
+    )
+
+    for (i in 1 until size) {
+
+        val prev = this[i - 1]
+        val current = this[i]
+        val midPoint = Offset(
+            x = (prev.x + current.x) / 2f,
+            y = (prev.y + current.y) / 2f
+        )
+
+        path.quadraticTo(
+            x1 = prev.x,
+            y1 = prev.y,
+            x2 = midPoint.x,
+            y2 = midPoint.y
+        )
+
+    }
+
+    // Ensure last point is included.
+    path.lineTo(
+        x = last().x,
+        y = last().y
+    )
+
+    return path
+
+}

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/core/ui/utils/ParticleUtils.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/core/ui/utils/ParticleUtils.kt
@@ -1,0 +1,28 @@
+package com.stoyanvuchev.magicmessage.core.ui.utils
+
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import com.stoyanvuchev.magicmessage.domain.model.Particle
+
+object ParticleUtils {
+
+    fun spawnParticles(
+        at: Offset,
+        brushColor: Color
+    ): List<Particle> {
+        val count = (1..6).random() // random number of particles per point
+        return List(count) {
+            Particle(
+                position = at,
+                velocity = Offset(
+                    x = (-1..1).random().toFloat() * 3f,
+                    y = (-1..1).random().toFloat() * 3f
+                ),
+                color = brushColor.copy(alpha = (50..100).random().toFloat() / 100),
+                size = (5..10).random().toFloat(),
+                lifetime = (300..1000).random().toLong()
+            )
+        }
+    }
+
+}

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/domain/BrushType.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/domain/BrushType.kt
@@ -1,0 +1,3 @@
+package com.stoyanvuchev.magicmessage.domain
+
+enum class BrushType { NORMAL, GLOW }

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/domain/model/Particle.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/domain/model/Particle.kt
@@ -1,0 +1,15 @@
+package com.stoyanvuchev.magicmessage.domain.model
+
+import androidx.compose.runtime.Stable
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+
+@Stable
+data class Particle(
+    var position: Offset,
+    var velocity: Offset,
+    var color: Color,
+    var size: Float,
+    var lifetime: Long,
+    var age: Long = 0L
+)

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/domain/model/StrokeModel.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/domain/model/StrokeModel.kt
@@ -1,0 +1,13 @@
+package com.stoyanvuchev.magicmessage.domain.model
+
+import androidx.compose.runtime.Stable
+import androidx.compose.ui.graphics.Color
+import com.stoyanvuchev.magicmessage.domain.BrushType
+
+@Stable
+data class StrokeModel(
+    val points: List<TimedPoint>,
+    val color: Color,
+    val width: Float,
+    val brush: BrushType
+)

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/domain/model/TimedPoint.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/domain/model/TimedPoint.kt
@@ -1,0 +1,10 @@
+package com.stoyanvuchev.magicmessage.domain.model
+
+import androidx.compose.runtime.Stable
+import androidx.compose.ui.geometry.Offset
+
+@Stable
+data class TimedPoint(
+    val offset: Offset,
+    val timestamp: Long
+)

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/MainActivity.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/MainActivity.kt
@@ -4,17 +4,38 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
-import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.systemBarsPadding
-import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.stringResource
-import com.stoyanvuchev.magicmessage.R
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.stoyanvuchev.magicmessage.core.ui.DrawingController
+import com.stoyanvuchev.magicmessage.core.ui.components.DrawingCanvas
 import com.stoyanvuchev.magicmessage.core.ui.theme.MagicMessageTheme
 import dagger.hilt.android.AndroidEntryPoint
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
@@ -25,22 +46,75 @@ class MainActivity : ComponentActivity() {
         setContent {
             MagicMessageTheme {
 
-                Box(
+                Column(
                     modifier = Modifier.Companion
                         .fillMaxSize()
                         .systemBarsPadding(),
-                    contentAlignment = Alignment.Companion.Center
+                    verticalArrangement = Arrangement.Center,
+                    horizontalAlignment = Alignment.CenterHorizontally
                 ) {
 
-                    Text(
-                        text = "Hello, ${stringResource(R.string.app_name)}!",
-                        color = MaterialTheme.colorScheme.onBackground
+                    val viewModel = hiltViewModel<DummyViewModel>()
+                    val controller by viewModel.controller.collectAsStateWithLifecycle()
+
+                    DrawingCanvas(
+                        modifier = Modifier
+                            .padding(horizontal = 32.dp)
+                            .fillMaxWidth()
+                            .aspectRatio(3f / 4f)
+                            .background(Color.Black),
+                        controller = controller
                     )
+
+                    Spacer(modifier = Modifier.height(8.dp))
+
+                    val progress by remember(controller.totalPointCount) {
+                        derivedStateOf {
+                            controller.totalPointCount.toFloat() / controller.maxPoints
+                        }
+                    }
+
+                    LinearProgressIndicator(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 32.dp),
+                        progress = { progress }
+                    )
+
+                    Spacer(modifier = Modifier.height(32.dp))
+
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.SpaceEvenly,
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+
+                        TextButton(
+                            onClick = remember { { controller.clear() } }
+                        ) { Text(text = "Reset") }
+
+                        TextButton(
+                            onClick = remember { { controller.undo() } }
+                        ) { Text(text = "Undo") }
+
+                        TextButton(
+                            onClick = remember { { controller.redo() } }
+                        ) { Text(text = "Redo") }
+
+                    }
 
                 }
 
             }
         }
     }
+
+}
+
+@HiltViewModel
+class DummyViewModel @Inject constructor() : ViewModel() {
+
+    private val _controller = MutableStateFlow(DrawingController())
+    val controller = _controller.asStateFlow()
 
 }


### PR DESCRIPTION
This commit introduces a fully functional drawing canvas with the following features:

- **Basic Drawing:** Users can draw strokes on the canvas.

- **Particle Effects:** Drawing actions spawn animated particles for a visual flair.

- **Glow Effect:** Current stroke being drawn has a glow effect.

- **Stroke Smoothing:** Drawn lines are smoothed using quadratic Bezier curves.

- **Point Limit:** A maximum number of points can be drawn to manage performance, with a progress indicator.

- **Undo/Redo Functionality:** Users can undo and redo their drawing actions.

- **Clear Canvas:** Option to clear the entire canvas.

- **Brush Types:** Introduces `NORMAL` and `GLOW` brush types.

- **Extensibility:** `DrawScope` and `List<Offset>` extensions for drawing and path smoothing.

- **Architecture:**
    - `DrawingController`: Manages drawing state, strokes, particles, and undo/redo logic.
    - `DrawingCanvas`: Composable function for rendering the canvas and handling user input.
    - `ParticleUpdater`: Manages particle physics updates in a separate coroutine.
    - `StrokeModel`, `TimedPoint`, `Particle`: Data models for drawing elements.
    - `ParticleUtils`: Utility for spawning particles.

- **UI:** Includes basic UI controls for reset, undo, and redo actions in `MainActivity`.