### PR TITLE
Implemented `CreationRepository` for managing drawing data.

### DIFF
--- a/.idea/androidTestResultsUserPreferences.xml
+++ b/.idea/androidTestResultsUserPreferences.xml
@@ -16,6 +16,19 @@
             </AndroidTestResultsTableState>
           </value>
         </entry>
+        <entry key="-711423172">
+          <value>
+            <AndroidTestResultsTableState>
+              <option name="preferredColumnWidths">
+                <map>
+                  <entry key="Duration" value="90" />
+                  <entry key="Pixel_7_Pro" value="120" />
+                  <entry key="Tests" value="360" />
+                </map>
+              </option>
+            </AndroidTestResultsTableState>
+          </value>
+        </entry>
         <entry key="1008442660">
           <value>
             <AndroidTestResultsTableState>

--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -22,6 +22,9 @@
       <SelectionState runConfigName="CreationDatabaseTest">
         <option name="selectionMode" value="DROPDOWN" />
       </SelectionState>
+      <SelectionState runConfigName="CreationRepositoryTest">
+        <option name="selectionMode" value="DROPDOWN" />
+      </SelectionState>
     </selectionStates>
   </component>
 </project>

--- a/app/src/androidTest/java/com/stoyanvuchev/magicmessage/data/repository/CreationRepositoryTest.kt
+++ b/app/src/androidTest/java/com/stoyanvuchev/magicmessage/data/repository/CreationRepositoryTest.kt
@@ -1,0 +1,113 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2025 Stoyan Vuchev
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES, OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.stoyanvuchev.magicmessage.data.repository
+
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNotNull
+import assertk.assertions.isNull
+import com.stoyanvuchev.magicmessage.data.local.CreationDao
+import com.stoyanvuchev.magicmessage.data.local.CreationDatabase
+import com.stoyanvuchev.magicmessage.data.local.StrokesConverter
+import com.stoyanvuchev.magicmessage.domain.model.StrokeModel
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class CreationRepositoryTest {
+
+    private lateinit var db: CreationDatabase
+    private lateinit var dao: CreationDao
+    private lateinit var repository: CreationRepositoryImpl
+
+    @Before
+    fun setUp() {
+
+        db = Room.inMemoryDatabaseBuilder(
+            ApplicationProvider.getApplicationContext(),
+            CreationDatabase::class.java
+        ).apply { addTypeConverter(StrokesConverter()) }.build()
+
+        dao = db.creationDao()
+        repository = CreationRepositoryImpl(dao)
+
+    }
+
+    @After
+    fun tearDown() {
+        if (::db.isInitialized) {
+            db.close()
+        }
+    }
+
+    @Test
+    fun saveOrUpdateDraft_inserts_whenNew() = runTest {
+        val id = repository.saveOrUpdateDraft(null, emptyList())
+        val loaded = repository.getById(id)
+
+        assertThat(loaded).isNotNull()
+        assertThat(loaded!!.id).isEqualTo(id)
+        assertThat(loaded.isDraft).isEqualTo(true)
+    }
+
+    @Test
+    fun saveOrUpdateDraft_updates_whenExisting() = runTest {
+        val id = repository.saveOrUpdateDraft(null, emptyList())
+        val updatedStrokes = listOf<StrokeModel>() // could populate later
+
+        val sameId = repository.saveOrUpdateDraft(id, updatedStrokes)
+        val loaded = repository.getById(sameId)
+
+        assertThat(sameId).isEqualTo(id)
+        assertThat(loaded!!.strokes).isEqualTo(updatedStrokes)
+    }
+
+    @Test
+    fun markAsFinished_updatesDraftToFinished() = runTest {
+        val id = repository.saveOrUpdateDraft(null, emptyList())
+        repository.markAsFinished(id, "preview.png")
+
+        val loaded = repository.getById(id)
+
+        assertThat(loaded!!.isDraft).isEqualTo(false)
+        assertThat(loaded.previewUri).isEqualTo("preview.png")
+    }
+
+    @Test
+    fun deleteById_removesEntity() = runTest {
+        val id = repository.saveOrUpdateDraft(null, emptyList())
+        repository.deleteById(id)
+
+        val loaded = repository.getById(id)
+        assertThat(loaded).isNull()
+    }
+
+}

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/data/local/CreationEntity.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/data/local/CreationEntity.kt
@@ -35,12 +35,12 @@ data class CreationEntity(
     @PrimaryKey(autoGenerate = true)
     val id: Long? = null,
 
-    val createdAt: Long,
-    val previewUri: String?,
-    val isDraft: Boolean,
-    val isFavorite: Boolean,
+    val createdAt: Long = 0L,
+    val previewUri: String? = "",
+    val isDraft: Boolean = true,
+    val isFavorite: Boolean = false,
 
     @param:TypeConverters(StrokesConverter::class)
-    val strokes: List<StrokeModel>
+    val strokes: List<StrokeModel> = emptyList()
 
 )

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/data/repository/CreationRepositoryImpl.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/data/repository/CreationRepositoryImpl.kt
@@ -1,0 +1,103 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2025 Stoyan Vuchev
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES, OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.stoyanvuchev.magicmessage.data.repository
+
+import com.stoyanvuchev.magicmessage.data.local.CreationDao
+import com.stoyanvuchev.magicmessage.data.local.CreationEntity
+import com.stoyanvuchev.magicmessage.domain.model.CreationModel
+import com.stoyanvuchev.magicmessage.domain.model.StrokeModel
+import com.stoyanvuchev.magicmessage.domain.repository.CreationRepository
+import com.stoyanvuchev.magicmessage.mappers.toModel
+import javax.inject.Inject
+
+class CreationRepositoryImpl @Inject constructor(
+    private val dao: CreationDao
+) : CreationRepository {
+
+    override suspend fun saveOrUpdateDraft(
+        draftId: Long?,
+        strokes: List<StrokeModel>
+    ): Long {
+
+        suspend fun insert() = dao.insert(
+            CreationEntity(
+                id = draftId,
+                strokes = strokes,
+                isDraft = true,
+                isFavorite = false,
+                createdAt = System.currentTimeMillis()
+            )
+        )
+
+        return if (draftId != null) {
+            val creation = dao.getById(draftId)
+            if (creation != null) {
+                dao.update(creation.copy(strokes = strokes))
+                draftId
+            } else insert()
+        } else insert()
+
+    }
+
+    override suspend fun markAsFinished(id: Long, previewUri: String?) {
+        val creation = dao.getById(id) ?: return
+        dao.update(creation.copy(isDraft = false, previewUri = previewUri))
+    }
+
+    override suspend fun markAsFavorite(id: Long) {
+        val creation = dao.getById(id) ?: return
+        dao.update(creation.copy(isFavorite = true))
+    }
+
+    override suspend fun removeAsFavorite(id: Long) {
+        val creation = dao.getById(id) ?: return
+        dao.update(creation.copy(isFavorite = false))
+    }
+
+    override suspend fun getDrafts(): List<CreationModel> {
+        return dao.getAllDrafts().map { it.toModel() }
+    }
+
+    override suspend fun getFinished(): List<CreationModel> {
+        return dao.getAll().map { it.toModel() }
+    }
+
+    override suspend fun getById(id: Long): CreationModel? {
+        return dao.getById(id)?.toModel()
+    }
+
+    override suspend fun deleteAllDrafts() {
+        dao.deleteAllDrafts()
+    }
+
+    override suspend fun deleteAllCreations() {
+        dao.deleteAllCreations()
+    }
+
+    override suspend fun deleteById(id: Long) {
+        dao.delete(dao.getById(id) ?: return)
+    }
+
+}

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/di/CreationModule.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/di/CreationModule.kt
@@ -22,40 +22,37 @@
  * SOFTWARE.
  */
 
-package com.stoyanvuchev.magicmessage.data.local
+package com.stoyanvuchev.magicmessage.di
 
-import androidx.room.Dao
-import androidx.room.Delete
-import androidx.room.Insert
-import androidx.room.OnConflictStrategy
-import androidx.room.Query
-import androidx.room.Update
+import android.app.Application
+import androidx.room.Room
+import com.stoyanvuchev.magicmessage.data.local.CreationDatabase
+import com.stoyanvuchev.magicmessage.data.repository.CreationRepositoryImpl
+import com.stoyanvuchev.magicmessage.domain.repository.CreationRepository
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
 
-@Dao
-interface CreationDao {
+@Module
+@InstallIn(SingletonComponent::class)
+object CreationModule {
 
-    @Insert(onConflict = OnConflictStrategy.REPLACE)
-    suspend fun insert(creation: CreationEntity): Long
+    @Provides
+    @Singleton
+    fun provideCreationDatabase(app: Application): CreationDatabase {
+        return Room.databaseBuilder(
+            app.applicationContext,
+            CreationDatabase::class.java,
+            "creation_db"
+        ).build()
+    }
 
-    @Update
-    suspend fun update(creation: CreationEntity)
-
-    @Delete
-    suspend fun delete(creation: CreationEntity)
-
-    @Query("SELECT * FROM creations WHERE isDraft IS 0 ORDER BY createdAt DESC")
-    suspend fun getAll(): List<CreationEntity>
-
-    @Query("SELECT * FROM creations WHERE isDraft IS 1 ORDER BY createdAt DESC")
-    suspend fun getAllDrafts(): List<CreationEntity>
-
-    @Query("SELECT * FROM creations WHERE id = :id")
-    suspend fun getById(id: Long): CreationEntity?
-
-    @Query("DELETE FROM creations WHERE isDraft IS 1")
-    suspend fun deleteAllDrafts()
-
-    @Query("DELETE FROM creations")
-    suspend fun deleteAllCreations()
+    @Provides
+    @Singleton
+    fun provideCreationRepository(db: CreationDatabase): CreationRepository {
+        return CreationRepositoryImpl(db.creationDao())
+    }
 
 }

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/domain/model/CreationModel.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/domain/model/CreationModel.kt
@@ -22,40 +22,16 @@
  * SOFTWARE.
  */
 
-package com.stoyanvuchev.magicmessage.data.local
+package com.stoyanvuchev.magicmessage.domain.model
 
-import androidx.room.Dao
-import androidx.room.Delete
-import androidx.room.Insert
-import androidx.room.OnConflictStrategy
-import androidx.room.Query
-import androidx.room.Update
+import androidx.compose.runtime.Stable
 
-@Dao
-interface CreationDao {
-
-    @Insert(onConflict = OnConflictStrategy.REPLACE)
-    suspend fun insert(creation: CreationEntity): Long
-
-    @Update
-    suspend fun update(creation: CreationEntity)
-
-    @Delete
-    suspend fun delete(creation: CreationEntity)
-
-    @Query("SELECT * FROM creations WHERE isDraft IS 0 ORDER BY createdAt DESC")
-    suspend fun getAll(): List<CreationEntity>
-
-    @Query("SELECT * FROM creations WHERE isDraft IS 1 ORDER BY createdAt DESC")
-    suspend fun getAllDrafts(): List<CreationEntity>
-
-    @Query("SELECT * FROM creations WHERE id = :id")
-    suspend fun getById(id: Long): CreationEntity?
-
-    @Query("DELETE FROM creations WHERE isDraft IS 1")
-    suspend fun deleteAllDrafts()
-
-    @Query("DELETE FROM creations")
-    suspend fun deleteAllCreations()
-
-}
+@Stable
+data class CreationModel(
+    val id: Long,
+    val createdAt: Long,
+    val previewUri: String?,
+    val isDraft: Boolean,
+    val isFavorite: Boolean,
+    val strokes: List<StrokeModel>
+)

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/domain/repository/CreationRepository.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/domain/repository/CreationRepository.kt
@@ -22,40 +22,32 @@
  * SOFTWARE.
  */
 
-package com.stoyanvuchev.magicmessage.data.local
+package com.stoyanvuchev.magicmessage.domain.repository
 
-import androidx.room.Dao
-import androidx.room.Delete
-import androidx.room.Insert
-import androidx.room.OnConflictStrategy
-import androidx.room.Query
-import androidx.room.Update
+import com.stoyanvuchev.magicmessage.domain.model.CreationModel
+import com.stoyanvuchev.magicmessage.domain.model.StrokeModel
 
-@Dao
-interface CreationDao {
+interface CreationRepository {
 
-    @Insert(onConflict = OnConflictStrategy.REPLACE)
-    suspend fun insert(creation: CreationEntity): Long
+    suspend fun saveOrUpdateDraft(
+        draftId: Long?,
+        strokes: List<StrokeModel>
+    ): Long
 
-    @Update
-    suspend fun update(creation: CreationEntity)
+    suspend fun markAsFinished(
+        id: Long,
+        previewUri: String?
+    )
 
-    @Delete
-    suspend fun delete(creation: CreationEntity)
+    suspend fun markAsFavorite(id: Long)
+    suspend fun removeAsFavorite(id: Long)
 
-    @Query("SELECT * FROM creations WHERE isDraft IS 0 ORDER BY createdAt DESC")
-    suspend fun getAll(): List<CreationEntity>
+    suspend fun getDrafts(): List<CreationModel>
+    suspend fun getFinished(): List<CreationModel>
+    suspend fun getById(id: Long): CreationModel?
 
-    @Query("SELECT * FROM creations WHERE isDraft IS 1 ORDER BY createdAt DESC")
-    suspend fun getAllDrafts(): List<CreationEntity>
-
-    @Query("SELECT * FROM creations WHERE id = :id")
-    suspend fun getById(id: Long): CreationEntity?
-
-    @Query("DELETE FROM creations WHERE isDraft IS 1")
     suspend fun deleteAllDrafts()
-
-    @Query("DELETE FROM creations")
     suspend fun deleteAllCreations()
+    suspend fun deleteById(id: Long)
 
 }

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/mappers/CreationMappers.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/mappers/CreationMappers.kt
@@ -22,29 +22,25 @@
  * SOFTWARE.
  */
 
-package com.stoyanvuchev.magicmessage.di
+package com.stoyanvuchev.magicmessage.mappers
 
-import android.app.Application
-import androidx.room.Room
-import com.stoyanvuchev.magicmessage.data.local.CreationDatabase
-import dagger.Module
-import dagger.Provides
-import dagger.hilt.InstallIn
-import dagger.hilt.components.SingletonComponent
-import javax.inject.Singleton
+import com.stoyanvuchev.magicmessage.data.local.CreationEntity
+import com.stoyanvuchev.magicmessage.domain.model.CreationModel
 
-@Module
-@InstallIn(SingletonComponent::class)
-object CreationDatabaseModule {
+fun CreationEntity.toModel() = CreationModel(
+    id = id ?: 0,
+    createdAt = createdAt,
+    previewUri = previewUri,
+    isDraft = isDraft,
+    isFavorite = isFavorite,
+    strokes = strokes
+)
 
-    @Provides
-    @Singleton
-    fun provideCreationDatabase(app: Application): CreationDatabase {
-        return Room.databaseBuilder(
-            app.applicationContext,
-            CreationDatabase::class.java,
-            "creation_db"
-        ).build()
-    }
-
-}
+fun CreationModel.toEntity() = CreationEntity(
+    id = id,
+    createdAt = createdAt,
+    previewUri = previewUri,
+    isDraft = isDraft,
+    isFavorite = isFavorite,
+    strokes = strokes
+)


### PR DESCRIPTION
This commit introduces the `CreationRepository` interface and its implementation, `CreationRepositoryImpl`, to handle the persistence and retrieval of drawing creations. It also includes associated data models, mappers, and unit tests.

**Key Changes:**

- **`CreationRepository` Interface:**
    - Defined in `domain.repository` to outline methods for saving, updating, retrieving, and deleting drawing creations (drafts and finished pieces).
    - Methods include `saveOrUpdateDraft`, `markAsFinished`, `markAsFavorite`, `removeAsFavorite`, `getDrafts`, `getFinished`, `getById`, `deleteAllDrafts`, `deleteAllCreations`, and `deleteById`.

- **`CreationRepositoryImpl`:**
    - Implemented in `data.repository` using `CreationDao` for database interactions.
    - Provides concrete logic for all methods defined in the `CreationRepository` interface.

- **`CreationModel`:**
    - Created in `domain.model` as a stable data class representing a drawing creation, including its ID, creation timestamp, preview URI, draft status, favorite status, and list of strokes.

- **`CreationMappers.kt`:**
    - Added in `mappers` to provide extension functions `toModel()` and `toEntity()` for converting between `CreationEntity` (database representation) and `CreationModel` (domain representation).

- **`CreationModule` (DI):**
    - Renamed from `CreationDatabaseModule`.
    - Updated to provide `CreationRepository` as a singleton dependency using `CreationRepositoryImpl` and `CreationDatabase`.

- **`CreationEntity` Update:**
    - Added default values for `createdAt`, `previewUri`, `isDraft`, `isFavorite`, and `strokes` to simplify entity creation.

- **`CreationDao` Update:**
    - Modified the `getAll()` query to specifically fetch non-draft creations (`WHERE isDraft IS 0`).

- **`CreationRepositoryTest`:**
    - Added instrumented tests in `androidTest` for `CreationRepositoryImpl`.
    - Tests cover scenarios like saving new drafts, updating existing drafts, marking drafts as finished, and deleting creations.
    - Uses an in-memory Room database for testing.

- **Minor IDE Configuration:**
    - Updated `.idea/androidTestResultsUserPreferences.xml` and `.idea/deploymentTargetSelector.xml` likely due to running new test configurations.