### PR TITLE
Refactored drawing state management and introduced HomeScreen.

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -4,10 +4,10 @@
     <selectionStates>
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
-        <DropdownSelection timestamp="2025-09-19T16:33:57.278042Z">
+        <DropdownSelection timestamp="2025-09-20T14:09:06.590909Z">
           <Target type="DEFAULT_BOOT">
             <handle>
-              <DeviceId pluginId="LocalEmulator" identifier="path=/Users/stoyan/.android/avd/Pixel_7_Pro.avd" />
+              <DeviceId pluginId="LocalEmulator" identifier="path=/Users/stoyan/.android/avd/Pixel_6_Pro.avd" />
             </handle>
           </Target>
         </DropdownSelection>

--- a/app/src/androidTest/java/com/stoyanvuchev/magicmessage/data/local/CreationDatabaseTest.kt
+++ b/app/src/androidTest/java/com/stoyanvuchev/magicmessage/data/local/CreationDatabaseTest.kt
@@ -33,6 +33,7 @@ import assertk.assertThat
 import assertk.assertions.isEqualTo
 import assertk.assertions.isNotNull
 import assertk.assertions.isNull
+import com.stoyanvuchev.magicmessage.core.ui.DrawingController
 import com.stoyanvuchev.magicmessage.domain.brush.BrushEffect
 import com.stoyanvuchev.magicmessage.domain.model.StrokeModel
 import com.stoyanvuchev.magicmessage.domain.model.TimedPoint
@@ -80,11 +81,10 @@ class CreationDatabaseTest {
 
         val creation = CreationEntity(
             id = 0, // auto-gen
-            strokes = strokes,
             createdAt = System.currentTimeMillis(),
             isDraft = true,
             isFavorite = true,
-            previewUri = null
+            drawingSnapshot = DrawingController().snapshot().copy(strokes = strokes)
         )
 
         val id = dao.insert(creation)
@@ -92,7 +92,7 @@ class CreationDatabaseTest {
 
         assertThat(draft).isNotNull()
         assertThat(draft?.id).isEqualTo(id)
-        assertThat(draft?.strokes?.first()?.points?.size).isEqualTo(2)
+        assertThat(draft?.drawingSnapshot?.strokes?.first()?.points?.size).isEqualTo(2)
 
     }
 
@@ -100,17 +100,21 @@ class CreationDatabaseTest {
     fun markDraftAsFinished() = runTest {
         val creation = CreationEntity(
             id = 0,
-            strokes = emptyList(),
             createdAt = System.currentTimeMillis(),
             isDraft = true,
             isFavorite = true,
-            previewUri = null
+            drawingSnapshot = DrawingController().snapshot()
         )
 
         val id = dao.insert(creation)
-        dao.update(creation.copy(isDraft = false, previewUri = "content://preview"))
-        val draft = dao.getById(id)
+        dao.update(
+            creation.copy(
+                isDraft = false,
+                drawingSnapshot = DrawingController().snapshot()
+            )
+        )
 
+        val draft = dao.getById(id)
         assertThat(draft?.isDraft).isEqualTo(false)
 
     }
@@ -120,11 +124,10 @@ class CreationDatabaseTest {
         val id = dao.insert(
             CreationEntity(
                 id = 0,
-                strokes = emptyList(),
                 createdAt = System.currentTimeMillis(),
                 isDraft = true,
                 isFavorite = true,
-                previewUri = null
+                drawingSnapshot = DrawingController().snapshot()
             )
         )
         val creation = dao.getById(id)
@@ -140,11 +143,10 @@ class CreationDatabaseTest {
             dao.insert(
                 CreationEntity(
                     id = id,
-                    strokes = emptyList(),
                     createdAt = System.currentTimeMillis(),
                     isDraft = true,
                     isFavorite = true,
-                    previewUri = null
+                    drawingSnapshot = DrawingController().snapshot()
                 )
             )
         }
@@ -152,7 +154,7 @@ class CreationDatabaseTest {
         dao.deleteAllDrafts()
 
         val drafts = dao.getAllDrafts()
-        assertThat(drafts).isEqualTo(emptyList())
+        assertThat(drafts).isEqualTo(emptyList<CreationEntity>())
 
     }
 
@@ -163,11 +165,10 @@ class CreationDatabaseTest {
             dao.insert(
                 CreationEntity(
                     id = id,
-                    strokes = emptyList(),
                     createdAt = System.currentTimeMillis(),
                     isDraft = false,
                     isFavorite = true,
-                    previewUri = null
+                    drawingSnapshot = DrawingController().snapshot()
                 )
             )
         }
@@ -175,7 +176,7 @@ class CreationDatabaseTest {
         dao.deleteAllCreations()
 
         val drafts = dao.getAll()
-        assertThat(drafts).isEqualTo(emptyList())
+        assertThat(drafts).isEqualTo(emptyList<CreationEntity>())
 
     }
 

--- a/app/src/androidTest/java/com/stoyanvuchev/magicmessage/data/repository/CreationRepositoryTest.kt
+++ b/app/src/androidTest/java/com/stoyanvuchev/magicmessage/data/repository/CreationRepositoryTest.kt
@@ -31,6 +31,7 @@ import assertk.assertThat
 import assertk.assertions.isEqualTo
 import assertk.assertions.isNotNull
 import assertk.assertions.isNull
+import com.stoyanvuchev.magicmessage.core.ui.DrawingController
 import com.stoyanvuchev.magicmessage.data.local.CreationDao
 import com.stoyanvuchev.magicmessage.data.local.CreationDatabase
 import com.stoyanvuchev.magicmessage.data.local.CreationTypeConverters
@@ -71,44 +72,74 @@ class CreationRepositoryTest {
 
     @Test
     fun saveOrUpdateDraft_inserts_whenNew() = runTest {
-        val id = repository.saveOrUpdateDraft(null, emptyList(), DrawConfiguration())
+
+        val id = repository.saveOrUpdateDraft(
+            null,
+            DrawConfiguration(),
+            DrawingController().snapshot()
+        )
+
         val loaded = repository.getById(id)
 
         assertThat(loaded).isNotNull()
         assertThat(loaded!!.id).isEqualTo(id)
         assertThat(loaded.isDraft).isEqualTo(true)
+
     }
 
     @Test
     fun saveOrUpdateDraft_updates_whenExisting() = runTest {
-        val id = repository.saveOrUpdateDraft(null, emptyList(), DrawConfiguration())
+
+        val id = repository.saveOrUpdateDraft(
+            null,
+            DrawConfiguration(),
+            DrawingController().snapshot()
+        )
         val updatedStrokes = listOf<StrokeModel>() // could populate later
 
-        val sameId = repository.saveOrUpdateDraft(id, updatedStrokes, DrawConfiguration())
+        val sameId = repository.saveOrUpdateDraft(
+            id,
+            DrawConfiguration(),
+            DrawingController().snapshot().copy(strokes = updatedStrokes)
+        )
         val loaded = repository.getById(sameId)
 
         assertThat(sameId).isEqualTo(id)
-        assertThat(loaded!!.strokes).isEqualTo(updatedStrokes)
+        assertThat(loaded!!.drawingSnapshot.strokes).isEqualTo(updatedStrokes)
+
     }
 
     @Test
     fun markAsFinished_updatesDraftToFinished() = runTest {
-        val id = repository.saveOrUpdateDraft(null, emptyList(), DrawConfiguration())
-        repository.markAsFinished(id, "preview.png")
+
+        val id = repository.saveOrUpdateDraft(
+            null,
+            DrawConfiguration(),
+            DrawingController().snapshot()
+        )
+
+        repository.markAsFinished(id)
 
         val loaded = repository.getById(id)
 
         assertThat(loaded!!.isDraft).isEqualTo(false)
-        assertThat(loaded.previewUri).isEqualTo("preview.png")
+
     }
 
     @Test
     fun deleteById_removesEntity() = runTest {
-        val id = repository.saveOrUpdateDraft(null, emptyList(), DrawConfiguration())
+
+        val id = repository.saveOrUpdateDraft(
+            null,
+            DrawConfiguration(),
+            DrawingController().snapshot()
+        )
+
         repository.deleteById(id)
 
         val loaded = repository.getById(id)
         assertThat(loaded).isNull()
+
     }
 
 }

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/core/ui/ParticleUpdater.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/core/ui/ParticleUpdater.kt
@@ -35,32 +35,30 @@ import kotlinx.coroutines.withContext
 @Composable
 fun ParticleUpdater(
     controller: DrawingController,
-    effect: BrushEffect
-) {
-    if (effect != BrushEffect.NONE) {
-        LaunchedEffect(Unit) {
-            withContext(Dispatchers.Default) {
+    brushEffect: BrushEffect
+) = LaunchedEffect(controller, brushEffect) {
+    if (brushEffect != BrushEffect.NONE) {
+        withContext(Dispatchers.Default) {
 
-                var lastTime = System.currentTimeMillis()
-                while (isActive) {
+            var lastTime = System.currentTimeMillis()
+            while (isActive) {
 
-                    val now = System.currentTimeMillis()
-                    val delta = now - lastTime
-                    lastTime = now
+                val now = System.currentTimeMillis()
+                val delta = now - lastTime
+                lastTime = now
 
-                    // Update physics off UI thread.
-                    controller.updateParticles(delta)
+                // Update physics off UI thread.
+                controller.updateParticles(delta)
 
-                    // Sync to Compose state on Main thread.
-                    withContext(Dispatchers.Main) {
-                        controller.syncParticlesToUI()
-                    }
-
-                    delay(16L) // ~60fps
-
+                // Sync to Compose state on Main thread.
+                withContext(Dispatchers.Main) {
+                    controller.syncParticlesToUI()
                 }
 
+                delay(16L) // ~60fps
+
             }
+
         }
     }
 }

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/core/ui/components/AuraButton.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/core/ui/components/AuraButton.kt
@@ -1,0 +1,161 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2025 Stoyan Vuchev
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES, OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.stoyanvuchev.magicmessage.core.ui.components
+
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.VectorConverter
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.animateValue
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.keyframes
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.center
+import androidx.compose.ui.unit.dp
+import com.stoyanvuchev.magicmessage.core.ui.components.interaction.rememberRipple
+import com.stoyanvuchev.magicmessage.core.ui.effect.defaultHazeEffect
+import com.stoyanvuchev.magicmessage.core.ui.effect.innerAuraGlow
+import com.stoyanvuchev.magicmessage.core.ui.effect.outerAuraGlow
+import com.stoyanvuchev.magicmessage.core.ui.theme.Theme
+import dev.chrisbanes.haze.HazeState
+
+@Composable
+fun AuraButton(
+    modifier: Modifier = Modifier,
+    onClick: () -> Unit,
+    hazeState: HazeState,
+    isGlowVisible: Boolean = true,
+    glowColor: Color = Theme.colors.primary,
+    size: Dp = 48.dp,
+    content: @Composable (() -> Unit)
+) {
+
+    var centerOffset by remember { mutableStateOf(IntOffset.Zero) }
+    val transition = rememberInfiniteTransition(
+        label = "aura-button-transition"
+    )
+
+    val glowOffsetX1 by transition.animateValue(
+        initialValue = 0.dp,
+        targetValue = 0.dp,
+        typeConverter = Dp.VectorConverter,
+        animationSpec = infiniteRepeatable(
+            animation = keyframes {
+                (-2).dp at 0
+                6.dp at 1000
+                durationMillis = 2000
+            },
+            repeatMode = RepeatMode.Reverse
+        )
+
+    )
+
+    val glowOffsetX2 by transition.animateValue(
+        initialValue = 0.dp,
+        targetValue = 0.dp,
+        typeConverter = Dp.VectorConverter,
+        animationSpec = infiniteRepeatable(
+            animation = keyframes {
+                6.dp at 0
+                (-2).dp at 1000
+                durationMillis = 2000
+            },
+            repeatMode = RepeatMode.Reverse
+        )
+
+    )
+
+    val alpha by animateFloatAsState(
+        targetValue = if (isGlowVisible) 1f else 0f,
+        animationSpec = tween(durationMillis = 360)
+    )
+
+    Box(
+        modifier = Modifier
+            .size(size)
+            .onSizeChanged { centerOffset = it.center }
+            .clickable(
+                onClick = onClick,
+                interactionSource = remember { MutableInteractionSource() },
+                indication = rememberRipple(),
+                role = Role.Button
+            )
+            .outerAuraGlow(
+                color = glowColor,
+                centerOffset = centerOffset,
+                glowOffset1 = glowOffsetX1,
+                glowOffset2 = glowOffsetX2,
+                alpha = alpha
+            )
+            .clip(CircleShape)
+            .defaultHazeEffect(hazeState = hazeState)
+            .background(
+                color = glowColor.copy(alpha.coerceIn(0f, .25f)),
+                shape = CircleShape
+            )
+            .border(
+                width = 1.dp,
+                color = Theme.colors.outline,
+                shape = CircleShape
+            )
+            .innerAuraGlow(
+                color = glowColor,
+                centerOffset = centerOffset,
+                alpha = alpha
+            )
+            .then(modifier),
+        contentAlignment = Alignment.Center
+    ) {
+
+        CompositionLocalProvider(
+            LocalContentColor provides Theme.colors.onSurfaceElevationHigh,
+            content = content
+        )
+
+    }
+
+}

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/core/ui/effect/DefaultAuraGlow.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/core/ui/effect/DefaultAuraGlow.kt
@@ -27,25 +27,29 @@ package com.stoyanvuchev.magicmessage.core.ui.effect
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.dropShadow
+import androidx.compose.ui.draw.innerShadow
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.graphics.shadow.Shadow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 
-fun Modifier.defaultAuraGlow(
-    radius: Dp = 1.dp,
+fun Modifier.outerAuraGlow(
+    radius: Dp = 8.dp,
     color: Color,
     centerOffset: IntOffset,
-    glowOffset: Dp,
+    glowOffset1: Dp,
+    glowOffset2: Dp,
     alpha: Float,
-    spread: Dp = 0.dp
+    spread: Dp = 0.dp,
+    shape: Shape = CircleShape
 ): Modifier {
     return dropShadow(
-        shape = CircleShape,
+        shape = shape,
         shadow = Shadow(
             radius = radius,
             brush = Brush.radialGradient(
@@ -60,8 +64,60 @@ fun Modifier.defaultAuraGlow(
                 )
             ),
             offset = DpOffset(
-                x = glowOffset,
-                y = glowOffset
+                x = glowOffset1,
+                y = glowOffset1
+            ),
+            alpha = alpha,
+            spread = spread
+        )
+    ).then(
+        Modifier.dropShadow(
+            shape = shape,
+            shadow = Shadow(
+                radius = radius,
+                brush = Brush.radialGradient(
+                    colors = listOf(
+                        color,
+                        color.copy(.75f),
+                        color.copy(0f)
+                    ),
+                    center = Offset(
+                        x = centerOffset.x.toFloat(),
+                        y = centerOffset.y.toFloat()
+                    )
+                ),
+                offset = DpOffset(
+                    x = glowOffset2,
+                    y = glowOffset2
+                ),
+                alpha = alpha,
+                spread = spread
+            )
+        )
+    )
+}
+
+fun Modifier.innerAuraGlow(
+    radius: Dp = 8.dp,
+    color: Color,
+    centerOffset: IntOffset,
+    alpha: Float,
+    spread: Dp = (-0).dp,
+    shape: Shape = CircleShape
+): Modifier {
+    return innerShadow(
+        shape = shape,
+        shadow = Shadow(
+            radius = radius,
+            brush = Brush.radialGradient(
+                colors = listOf(
+                    color.copy(0f),
+                    color
+                ),
+                center = Offset(
+                    x = centerOffset.x.toFloat(),
+                    y = centerOffset.y.toFloat()
+                )
             ),
             alpha = alpha,
             spread = spread

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/core/ui/effect/DefaultHazeEffect.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/core/ui/effect/DefaultHazeEffect.kt
@@ -40,7 +40,7 @@ fun Modifier.defaultHazeEffect(
         hazeEffect(
             state = hazeState,
             style = HazeStyle(
-                tint = HazeTint(color = Theme.colors.surfaceElevationLow.copy(.5f)),
+                tint = HazeTint(color = Theme.colors.surfaceElevationLow.copy(.75f)),
                 blurRadius = 16.dp,
                 noiseFactor = -.5f,
                 backgroundColor = Theme.colors.surfaceElevationLow

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/core/ui/event/NavigationEvent.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/core/ui/event/NavigationEvent.kt
@@ -28,7 +28,12 @@ import androidx.compose.runtime.Immutable
 import com.stoyanvuchev.magicmessage.core.ui.navigation.NavigationScreen
 
 @Immutable
-interface NavigationEvent {
+sealed interface NavigationEvent {
+
     data object NavigateUp : NavigationEvent
-    data class NavigateTo(val screen: NavigationScreen) : NavigationEvent
+
+    data class NavigateTo(
+        val screen: NavigationScreen
+    ) : NavigationEvent
+
 }

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/data/local/CreationDao.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/data/local/CreationDao.kt
@@ -30,6 +30,7 @@ import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import androidx.room.Update
+import kotlinx.coroutines.flow.Flow
 
 @Dao
 interface CreationDao {
@@ -43,11 +44,11 @@ interface CreationDao {
     @Delete
     suspend fun delete(creation: CreationEntity)
 
-    @Query("SELECT * FROM creations WHERE isDraft IS 0 ORDER BY createdAt DESC")
-    suspend fun getAll(): List<CreationEntity>
+    @Query("SELECT * FROM creations WHERE isDraft IS FALSE ORDER BY createdAt DESC")
+    fun getAll(): Flow<List<CreationEntity>>
 
-    @Query("SELECT * FROM creations WHERE isDraft IS 1 ORDER BY createdAt DESC")
-    suspend fun getAllDrafts(): List<CreationEntity>
+    @Query("SELECT * FROM creations WHERE isDraft IS TRUE ORDER BY createdAt DESC")
+    fun getAllDrafts(): Flow<List<CreationEntity>>
 
     @Query("SELECT * FROM creations WHERE id = :id")
     suspend fun getById(id: Long): CreationEntity?

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/data/local/CreationEntity.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/data/local/CreationEntity.kt
@@ -28,8 +28,10 @@ import androidx.room.Entity
 import androidx.room.PrimaryKey
 import androidx.room.TypeConverters
 import com.stoyanvuchev.magicmessage.domain.model.DrawConfiguration
-import com.stoyanvuchev.magicmessage.domain.model.StrokeModel
+import com.stoyanvuchev.magicmessage.domain.model.DrawingSnapshot
+import kotlinx.serialization.Serializable
 
+@Serializable
 @Entity(tableName = "creations")
 data class CreationEntity(
 
@@ -37,14 +39,13 @@ data class CreationEntity(
     val id: Long? = null,
 
     val createdAt: Long = 0L,
-    val previewUri: String? = "",
     val isDraft: Boolean = true,
     val isFavorite: Boolean = false,
 
     @param:TypeConverters(CreationTypeConverters::class)
-    val strokes: List<StrokeModel> = emptyList(),
+    val drawConfiguration: DrawConfiguration = DrawConfiguration(),
 
     @param:TypeConverters(CreationTypeConverters::class)
-    val drawConfiguration: DrawConfiguration = DrawConfiguration()
+    val drawingSnapshot: DrawingSnapshot
 
 )

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/data/local/CreationTypeConverters.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/data/local/CreationTypeConverters.kt
@@ -32,6 +32,7 @@ import androidx.room.TypeConverter
 import com.stoyanvuchev.magicmessage.domain.brush.BrushEffect
 import com.stoyanvuchev.magicmessage.domain.layer.BackgroundLayer
 import com.stoyanvuchev.magicmessage.domain.model.DrawConfiguration
+import com.stoyanvuchev.magicmessage.domain.model.DrawingSnapshot
 import com.stoyanvuchev.magicmessage.domain.model.StrokeModel
 import com.stoyanvuchev.magicmessage.domain.model.TimedPoint
 import com.stoyanvuchev.magicmessage.domain.serializer.BackgroundLayerSerializer
@@ -143,6 +144,16 @@ class CreationTypeConverters {
     @TypeConverter
     fun toDrawConfiguration(data: String): DrawConfiguration {
         return json.decodeFromString(data)
+    }
+
+    @TypeConverter
+    fun fromDrawingSnapshot(snapshot: DrawingSnapshot): String {
+        return json.encodeToString(DrawingSnapshot.serializer(), snapshot)
+    }
+
+    @TypeConverter
+    fun toDrawingSnapshot(data: String): DrawingSnapshot {
+        return json.decodeFromString(DrawingSnapshot.serializer(), data)
     }
 
 }

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/di/CreationModule.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/di/CreationModule.kt
@@ -31,6 +31,9 @@ import com.stoyanvuchev.magicmessage.data.local.CreationTypeConverters
 import com.stoyanvuchev.magicmessage.data.repository.CreationRepositoryImpl
 import com.stoyanvuchev.magicmessage.domain.repository.CreationRepository
 import com.stoyanvuchev.magicmessage.domain.usecase.CreationGetByIdUseCase
+import com.stoyanvuchev.magicmessage.domain.usecase.CreationGetDraftsUseCase
+import com.stoyanvuchev.magicmessage.domain.usecase.CreationGetExportedUseCase
+import com.stoyanvuchev.magicmessage.domain.usecase.CreationMarkAsExportedUseCase
 import com.stoyanvuchev.magicmessage.domain.usecase.CreationSaveOrUpdateUseCase
 import com.stoyanvuchev.magicmessage.domain.usecase.CreationUseCases
 import dagger.Module
@@ -75,7 +78,10 @@ object CreationModule {
     ): CreationUseCases {
         return CreationUseCases(
             saveOrUpdateUseCase = CreationSaveOrUpdateUseCase(repository),
-            getByIdUseCase = CreationGetByIdUseCase(repository)
+            getByIdUseCase = CreationGetByIdUseCase(repository),
+            getExportedUseCase = CreationGetExportedUseCase(repository),
+            getDraftsUseCase = CreationGetDraftsUseCase(repository),
+            markAsExportedUseCase = CreationMarkAsExportedUseCase(repository)
         )
     }
 

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/domain/model/CreationModel.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/domain/model/CreationModel.kt
@@ -25,14 +25,15 @@
 package com.stoyanvuchev.magicmessage.domain.model
 
 import androidx.compose.runtime.Stable
+import kotlinx.serialization.Serializable
 
 @Stable
+@Serializable
 data class CreationModel(
-    val id: Long,
+    val id: Long?,
     val createdAt: Long,
-    val previewUri: String?,
     val isDraft: Boolean,
     val isFavorite: Boolean,
-    val strokes: List<StrokeModel>,
-    val drawConfiguration: DrawConfiguration
+    val drawConfiguration: DrawConfiguration,
+    val drawingSnapshot: DrawingSnapshot
 )

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/domain/model/DrawingSnapshot.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/domain/model/DrawingSnapshot.kt
@@ -1,0 +1,16 @@
+package com.stoyanvuchev.magicmessage.domain.model
+
+import androidx.compose.runtime.Stable
+import kotlinx.serialization.Serializable
+
+@Stable
+@Serializable
+data class DrawingSnapshot(
+    val totalPointCount: Int,
+    val drawingEnabled: Boolean,
+    val strokes: List<StrokeModel>,
+    val currentPoints: List<TimedPoint>,
+    val undoStack: List<StrokeModel>,
+    val redoStack: List<StrokeModel>,
+    val startTime: Long
+)

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/domain/model/Particle.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/domain/model/Particle.kt
@@ -24,16 +24,26 @@
 
 package com.stoyanvuchev.magicmessage.domain.model
 
-import androidx.compose.runtime.Stable
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
+import com.stoyanvuchev.magicmessage.domain.serializer.ColorSerializer
+import com.stoyanvuchev.magicmessage.domain.serializer.OffsetSerializer
+import kotlinx.serialization.Serializable
 
-@Stable
+@Serializable
 data class Particle(
+
+    @Serializable(with = OffsetSerializer::class)
     var position: Offset,
+
+    @Serializable(with = OffsetSerializer::class)
     var velocity: Offset,
+
+    @Serializable(with = ColorSerializer::class)
     var color: Color,
+
     var size: Float,
     var lifetime: Long,
     var age: Long = 0L
+
 )

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/domain/repository/CreationRepository.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/domain/repository/CreationRepository.kt
@@ -26,26 +26,24 @@ package com.stoyanvuchev.magicmessage.domain.repository
 
 import com.stoyanvuchev.magicmessage.domain.model.CreationModel
 import com.stoyanvuchev.magicmessage.domain.model.DrawConfiguration
-import com.stoyanvuchev.magicmessage.domain.model.StrokeModel
+import com.stoyanvuchev.magicmessage.domain.model.DrawingSnapshot
+import kotlinx.coroutines.flow.Flow
 
 interface CreationRepository {
 
     suspend fun saveOrUpdateDraft(
         draftId: Long?,
-        strokes: List<StrokeModel>,
-        drawConfiguration: DrawConfiguration
+        drawConfiguration: DrawConfiguration,
+        drawingSnapshot: DrawingSnapshot
     ): Long
 
-    suspend fun markAsFinished(
-        id: Long,
-        previewUri: String?
-    )
+    suspend fun markAsFinished(messageId: Long)
 
     suspend fun markAsFavorite(id: Long)
     suspend fun removeAsFavorite(id: Long)
 
-    suspend fun getDrafts(): List<CreationModel>
-    suspend fun getFinished(): List<CreationModel>
+    fun getDrafts(): Flow<List<CreationModel>>
+    fun getFinished(): Flow<List<CreationModel>>
     suspend fun getById(id: Long): CreationModel?
 
     suspend fun deleteAllDrafts()

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/domain/serializer/AnyAsStringSerializer.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/domain/serializer/AnyAsStringSerializer.kt
@@ -22,15 +22,26 @@
  * SOFTWARE.
  */
 
-package com.stoyanvuchev.magicmessage.presentation.main.draw_screen
+package com.stoyanvuchev.magicmessage.domain.serializer
 
-import androidx.compose.runtime.Stable
-import com.stoyanvuchev.magicmessage.domain.model.DrawConfiguration
-import com.stoyanvuchev.magicmessage.presentation.main.draw_screen.dialog.DialogEditType
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
 
-@Stable
-data class DrawScreenState(
-    val messageId: Long? = null,
-    val dialogEditType: DialogEditType = DialogEditType.NONE,
-    val drawConfiguration: DrawConfiguration = DrawConfiguration()
-)
+object AnyAsStringSerializer : KSerializer<Any> {
+
+    override val descriptor: SerialDescriptor =
+        PrimitiveSerialDescriptor("AnyAsString", PrimitiveKind.STRING)
+
+    override fun serialize(encoder: Encoder, value: Any) {
+        encoder.encodeString(value.toString())
+    }
+
+    override fun deserialize(decoder: Decoder): Any {
+        return decoder.decodeString()
+    }
+
+}

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/domain/serializer/ArrayDequeSerializer.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/domain/serializer/ArrayDequeSerializer.kt
@@ -22,15 +22,28 @@
  * SOFTWARE.
  */
 
-package com.stoyanvuchev.magicmessage.presentation.main.draw_screen
+package com.stoyanvuchev.magicmessage.domain.serializer
 
-import androidx.compose.runtime.Stable
-import com.stoyanvuchev.magicmessage.domain.model.DrawConfiguration
-import com.stoyanvuchev.magicmessage.presentation.main.draw_screen.dialog.DialogEditType
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
 
-@Stable
-data class DrawScreenState(
-    val messageId: Long? = null,
-    val dialogEditType: DialogEditType = DialogEditType.NONE,
-    val drawConfiguration: DrawConfiguration = DrawConfiguration()
-)
+open class ArrayDequeSerializer<T>(
+    dataSerializer: KSerializer<T>
+) : KSerializer<ArrayDeque<T>> {
+
+    private val delegate = ListSerializer(dataSerializer)
+
+    override val descriptor: SerialDescriptor = delegate.descriptor
+
+    override fun serialize(encoder: Encoder, value: ArrayDeque<T>) {
+        delegate.serialize(encoder, value.toList())
+    }
+
+    override fun deserialize(decoder: Decoder): ArrayDeque<T> {
+        val list = delegate.deserialize(decoder)
+        return ArrayDeque<T>().apply { addAll(list) }
+    }
+}

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/domain/serializer/SerializerColection.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/domain/serializer/SerializerColection.kt
@@ -22,15 +22,20 @@
  * SOFTWARE.
  */
 
-package com.stoyanvuchev.magicmessage.presentation.main.draw_screen
+package com.stoyanvuchev.magicmessage.domain.serializer
 
-import androidx.compose.runtime.Stable
-import com.stoyanvuchev.magicmessage.domain.model.DrawConfiguration
-import com.stoyanvuchev.magicmessage.presentation.main.draw_screen.dialog.DialogEditType
+import com.stoyanvuchev.magicmessage.domain.model.Particle
+import com.stoyanvuchev.magicmessage.domain.model.StrokeModel
+import com.stoyanvuchev.magicmessage.domain.model.TimedPoint
 
-@Stable
-data class DrawScreenState(
-    val messageId: Long? = null,
-    val dialogEditType: DialogEditType = DialogEditType.NONE,
-    val drawConfiguration: DrawConfiguration = DrawConfiguration()
-)
+object StrokeModelListSerializer :
+    SnapshotStateListSerializer<StrokeModel>(StrokeModel.serializer())
+
+object ParticleListSerializer :
+    SnapshotStateListSerializer<Particle>(Particle.serializer())
+
+object TimedPointListSerializer :
+    SnapshotStateListSerializer<TimedPoint>(TimedPoint.serializer())
+
+object StrokeDequeSerializer :
+    ArrayDequeSerializer<StrokeModel>(StrokeModel.serializer())

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/domain/serializer/SnapshotStateListSerializer.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/domain/serializer/SnapshotStateListSerializer.kt
@@ -22,15 +22,30 @@
  * SOFTWARE.
  */
 
-package com.stoyanvuchev.magicmessage.presentation.main.draw_screen
+package com.stoyanvuchev.magicmessage.domain.serializer
 
-import androidx.compose.runtime.Stable
-import com.stoyanvuchev.magicmessage.domain.model.DrawConfiguration
-import com.stoyanvuchev.magicmessage.presentation.main.draw_screen.dialog.DialogEditType
+import androidx.compose.runtime.snapshots.SnapshotStateList
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
 
-@Stable
-data class DrawScreenState(
-    val messageId: Long? = null,
-    val dialogEditType: DialogEditType = DialogEditType.NONE,
-    val drawConfiguration: DrawConfiguration = DrawConfiguration()
-)
+open class SnapshotStateListSerializer<T>(
+    dataSerializer: KSerializer<T>
+) : KSerializer<SnapshotStateList<T>> {
+
+    private val listSerializer = ListSerializer(dataSerializer)
+
+    override val descriptor: SerialDescriptor =
+        listSerializer.descriptor
+
+    override fun serialize(encoder: Encoder, value: SnapshotStateList<T>) {
+        listSerializer.serialize(encoder, value.toList())
+    }
+
+    override fun deserialize(decoder: Decoder): SnapshotStateList<T> {
+        val list = listSerializer.deserialize(decoder)
+        return SnapshotStateList<T>().also { it.addAll(list) }
+    }
+}

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/domain/usecase/CreationGetDraftsUseCase.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/domain/usecase/CreationGetDraftsUseCase.kt
@@ -22,15 +22,19 @@
  * SOFTWARE.
  */
 
-package com.stoyanvuchev.magicmessage.presentation.main.draw_screen
+package com.stoyanvuchev.magicmessage.domain.usecase
 
-import androidx.compose.runtime.Stable
-import com.stoyanvuchev.magicmessage.domain.model.DrawConfiguration
-import com.stoyanvuchev.magicmessage.presentation.main.draw_screen.dialog.DialogEditType
+import com.stoyanvuchev.magicmessage.domain.model.CreationModel
+import com.stoyanvuchev.magicmessage.domain.repository.CreationRepository
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
 
-@Stable
-data class DrawScreenState(
-    val messageId: Long? = null,
-    val dialogEditType: DialogEditType = DialogEditType.NONE,
-    val drawConfiguration: DrawConfiguration = DrawConfiguration()
-)
+class CreationGetDraftsUseCase @Inject constructor(
+    private val repository: CreationRepository
+) {
+
+    operator fun invoke(): Flow<List<CreationModel>> {
+        return repository.getDrafts()
+    }
+
+}

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/domain/usecase/CreationGetExportedUseCase.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/domain/usecase/CreationGetExportedUseCase.kt
@@ -22,15 +22,19 @@
  * SOFTWARE.
  */
 
-package com.stoyanvuchev.magicmessage.presentation.main.draw_screen
+package com.stoyanvuchev.magicmessage.domain.usecase
 
-import androidx.compose.runtime.Stable
-import com.stoyanvuchev.magicmessage.domain.model.DrawConfiguration
-import com.stoyanvuchev.magicmessage.presentation.main.draw_screen.dialog.DialogEditType
+import com.stoyanvuchev.magicmessage.domain.model.CreationModel
+import com.stoyanvuchev.magicmessage.domain.repository.CreationRepository
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
 
-@Stable
-data class DrawScreenState(
-    val messageId: Long? = null,
-    val dialogEditType: DialogEditType = DialogEditType.NONE,
-    val drawConfiguration: DrawConfiguration = DrawConfiguration()
-)
+class CreationGetExportedUseCase @Inject constructor(
+    private val repository: CreationRepository
+) {
+
+    operator fun invoke(): Flow<List<CreationModel>> {
+        return repository.getFinished()
+    }
+
+}

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/domain/usecase/CreationMarkAsExportedUseCase.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/domain/usecase/CreationMarkAsExportedUseCase.kt
@@ -22,15 +22,17 @@
  * SOFTWARE.
  */
 
-package com.stoyanvuchev.magicmessage.presentation.main.draw_screen
+package com.stoyanvuchev.magicmessage.domain.usecase
 
-import androidx.compose.runtime.Stable
-import com.stoyanvuchev.magicmessage.domain.model.DrawConfiguration
-import com.stoyanvuchev.magicmessage.presentation.main.draw_screen.dialog.DialogEditType
+import com.stoyanvuchev.magicmessage.domain.repository.CreationRepository
+import javax.inject.Inject
 
-@Stable
-data class DrawScreenState(
-    val messageId: Long? = null,
-    val dialogEditType: DialogEditType = DialogEditType.NONE,
-    val drawConfiguration: DrawConfiguration = DrawConfiguration()
-)
+class CreationMarkAsExportedUseCase @Inject constructor(
+    private val repository: CreationRepository
+) {
+
+    suspend operator fun invoke(messageId: Long) {
+        repository.markAsFinished(messageId = messageId)
+    }
+
+}

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/domain/usecase/CreationSaveOrUpdateUseCase.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/domain/usecase/CreationSaveOrUpdateUseCase.kt
@@ -25,6 +25,7 @@
 package com.stoyanvuchev.magicmessage.domain.usecase
 
 import com.stoyanvuchev.magicmessage.domain.model.DrawConfiguration
+import com.stoyanvuchev.magicmessage.domain.model.DrawingSnapshot
 import com.stoyanvuchev.magicmessage.domain.model.StrokeModel
 import com.stoyanvuchev.magicmessage.domain.repository.CreationRepository
 import javax.inject.Inject
@@ -35,10 +36,16 @@ class CreationSaveOrUpdateUseCase @Inject constructor(
 
     suspend operator fun invoke(
         draftId: Long?,
-        strokes: List<StrokeModel>,
-        drawConfiguration: DrawConfiguration
+        drawConfiguration: DrawConfiguration,
+        drawingSnapshot: DrawingSnapshot
     ): Long {
-        return repository.saveOrUpdateDraft(draftId, strokes, drawConfiguration)
+
+        return repository.saveOrUpdateDraft(
+            draftId = draftId,
+            drawConfiguration = drawConfiguration,
+            drawingSnapshot = drawingSnapshot
+        )
+
     }
 
 }

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/domain/usecase/CreationUseCases.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/domain/usecase/CreationUseCases.kt
@@ -27,4 +27,7 @@ package com.stoyanvuchev.magicmessage.domain.usecase
 data class CreationUseCases(
     val saveOrUpdateUseCase: CreationSaveOrUpdateUseCase,
     val getByIdUseCase: CreationGetByIdUseCase,
+    val getExportedUseCase: CreationGetExportedUseCase,
+    val getDraftsUseCase: CreationGetDraftsUseCase,
+    val markAsExportedUseCase: CreationMarkAsExportedUseCase
 )

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/framework/export/Exporter.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/framework/export/Exporter.kt
@@ -147,6 +147,8 @@ class Exporter @Inject constructor(
                 elapsedTime += strokeEnd - strokeStart
             }
 
+        } catch (e: Exception) {
+            e.printStackTrace()
         } finally {
             encoder.close()
         }

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/mappers/CreationMappers.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/mappers/CreationMappers.kt
@@ -30,9 +30,8 @@ import com.stoyanvuchev.magicmessage.domain.model.CreationModel
 fun CreationEntity.toModel() = CreationModel(
     id = id ?: 0,
     createdAt = createdAt,
-    previewUri = previewUri,
     isDraft = isDraft,
     isFavorite = isFavorite,
-    strokes = strokes,
-    drawConfiguration = drawConfiguration
+    drawConfiguration = drawConfiguration,
+    drawingSnapshot = drawingSnapshot
 )

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/AppBottomNavBar.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/AppBottomNavBar.kt
@@ -27,10 +27,16 @@ package com.stoyanvuchev.magicmessage.presentation
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
+import androidx.compose.animation.scaleIn
+import androidx.compose.animation.scaleOut
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -39,15 +45,20 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
 import androidx.navigation.NavDestination.Companion.hasRoute
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.currentBackStackEntryAsState
+import com.stoyanvuchev.magicmessage.R
+import com.stoyanvuchev.magicmessage.core.ui.components.AuraButton
 import com.stoyanvuchev.magicmessage.core.ui.components.bottom_nav_bar.BottomNavBar
 import com.stoyanvuchev.magicmessage.core.ui.components.bottom_nav_bar.BottomNavBarItem
 import com.stoyanvuchev.magicmessage.core.ui.effect.defaultHazeEffect
+import com.stoyanvuchev.magicmessage.presentation.main.MainScreen
 import com.stoyanvuchev.magicmessage.presentation.main.mainScreenNavDestinations
 import dev.chrisbanes.haze.HazeState
 
@@ -81,38 +92,88 @@ fun AppBottomNavBar(
         exit = remember { slideOutVertically { it } + fadeOut() }
     ) {
 
-        BottomNavBar(
-            modifier = Modifier.defaultHazeEffect(hazeState = hazeState)
+        Column(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalAlignment = Alignment.CenterHorizontally
         ) {
 
-            destinations.forEachIndexed { index, destination ->
-
-                val selected by remember(currentDestination, index) {
-                    derivedStateOf {
-                        currentDestination
-                            ?.hasRoute(destination::class)
-                            ?: false
-                    }
+            val isAuraBtnVisible by remember(currentDestination) {
+                derivedStateOf {
+                    currentDestination?.hasRoute(MainScreen.Home::class) ?: false
                 }
+            }
 
-                BottomNavBarItem(
-                    selected = selected,
-                    onClick = { navController.navigate(destination) },
-                    icon = { offsetY ->
+            AnimatedVisibility(
+                modifier = Modifier.size(100.dp),
+                visible = isAuraBtnVisible,
+                enter = remember { fadeIn() + scaleIn(initialScale = .8f) },
+                exit = remember { scaleOut(targetScale = .8f) + fadeOut() }
+            ) {
+
+                Box(
+                    modifier = Modifier.fillMaxSize(),
+                    contentAlignment = Alignment.Center
+                ) {
+
+                    AuraButton(
+                        onClick = remember {
+                            {
+                                navController.navigate(
+                                    MainScreen.Draw(null)
+                                ) { launchSingleTop = true }
+                            }
+                        },
+                        hazeState = hazeState,
+                        isGlowVisible = true,
+                        size = 56.dp
+                    ) {
 
                         Icon(
-                            modifier = Modifier.offset(y = offsetY),
-                            painter = painterResource(destination.icon),
+                            modifier = Modifier.size(24.dp),
+                            painter = painterResource(R.drawable.pencil_icon),
                             contentDescription = null
                         )
 
-                    },
-                    label = {
-
-                        Text(text = stringResource(destination.label))
-
                     }
-                )
+
+                }
+
+            }
+
+            BottomNavBar(
+                modifier = Modifier.defaultHazeEffect(hazeState = hazeState)
+            ) {
+
+                destinations.forEachIndexed { index, destination ->
+
+                    val selected by remember(currentDestination, index) {
+                        derivedStateOf {
+                            currentDestination
+                                ?.hasRoute(destination::class)
+                                ?: false
+                        }
+                    }
+
+                    BottomNavBarItem(
+                        selected = selected,
+                        onClick = { navController.navigate(destination) },
+                        icon = { offsetY ->
+
+                            Icon(
+                                modifier = Modifier.offset(y = offsetY),
+                                painter = painterResource(destination.icon),
+                                contentDescription = null
+                            )
+
+                        },
+                        label = {
+
+                            Text(text = stringResource(destination.label))
+
+                        }
+                    )
+
+                }
 
             }
 

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/AppNavHost.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/AppNavHost.kt
@@ -77,7 +77,7 @@ fun AppNavHost(
                 LaunchedEffect(isBoardingComplete) {
                     if (isBoardingComplete != null) {
                         navController.navigate(
-                            if (isBoardingComplete) MainScreen.Draw(0L) // fixme: To be changed.
+                            if (isBoardingComplete) MainScreen.Home
                             else BoardingScreen.GetStarted
                         ) {
                             popUpTo(navController.graph.id) { inclusive = false }

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/main/MainScreen.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/main/MainScreen.kt
@@ -64,7 +64,7 @@ sealed class MainScreen(
     )
 
     @Serializable
-    data class Draw(val messageId: Long) : MainScreen(
+    data class Draw(val messageId: Long?) : MainScreen(
         label = R.string.draw_screen_label,
         icon = R.drawable.logo_icon
     )

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/main/draw_screen/DrawScreen.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/main/draw_screen/DrawScreen.kt
@@ -55,6 +55,7 @@ import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import com.stoyanvuchev.magicmessage.core.ui.DrawingController
+import com.stoyanvuchev.magicmessage.core.ui.event.NavigationEvent
 import com.stoyanvuchev.magicmessage.core.ui.theme.Theme
 import com.stoyanvuchev.magicmessage.core.ui.theme.isInDarkThemeMode
 import com.stoyanvuchev.magicmessage.framework.export.ExporterState
@@ -75,7 +76,8 @@ fun DrawScreen(
     exporterState: ExporterState,
     exportedUri: Uri?,
     drawingController: DrawingController,
-    onUIAction: (DrawScreenUIAction) -> Unit
+    onUIAction: (DrawScreenUIAction) -> Unit,
+    onNavigationEvent: (NavigationEvent) -> Unit
 ) {
 
     val hazeState = rememberHazeState()
@@ -122,11 +124,12 @@ fun DrawScreen(
         topBar = {
 
             DrawScreenTopBar(
-                hazeState = hazeState,
                 state = state,
+                hazeState = hazeState,
                 drawingController = drawingController,
                 canvasSize = canvasSize,
-                onUIAction = onUIAction
+                onUIAction = onUIAction,
+                onNavigationEvent = onNavigationEvent
             )
 
         },
@@ -164,7 +167,7 @@ fun DrawScreen(
 
             val progress by remember(drawingController.totalPointCount) {
                 derivedStateOf {
-                    drawingController.totalPointCount.toFloat() / drawingController.maxPoints
+                    drawingController.totalPointCount.toFloat() / DrawingController.MAX_POINTS
                 }
             }
 

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/main/draw_screen/DrawScreenTopBar.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/main/draw_screen/DrawScreenTopBar.kt
@@ -24,51 +24,35 @@
 
 package com.stoyanvuchev.magicmessage.presentation.main.draw_screen
 
-import androidx.compose.animation.core.RepeatMode
-import androidx.compose.animation.core.VectorConverter
-import androidx.compose.animation.core.animateFloatAsState
-import androidx.compose.animation.core.animateValue
-import androidx.compose.animation.core.infiniteRepeatable
-import androidx.compose.animation.core.keyframes
-import androidx.compose.animation.core.rememberInfiniteTransition
-import androidx.compose.animation.core.tween
-import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.IconButtonDefaults
-import androidx.compose.material3.OutlinedIconButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.unit.Dp
-import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntSize
-import androidx.compose.ui.unit.center
 import androidx.compose.ui.unit.dp
 import com.stoyanvuchev.magicmessage.R
 import com.stoyanvuchev.magicmessage.core.ui.DrawingController
+import com.stoyanvuchev.magicmessage.core.ui.components.AuraButton
 import com.stoyanvuchev.magicmessage.core.ui.components.top_bar.TopBar
-import com.stoyanvuchev.magicmessage.core.ui.effect.defaultAuraGlow
 import com.stoyanvuchev.magicmessage.core.ui.effect.defaultHazeEffect
-import com.stoyanvuchev.magicmessage.core.ui.theme.Theme
+import com.stoyanvuchev.magicmessage.core.ui.event.NavigationEvent
 import dev.chrisbanes.haze.HazeState
 
 @Composable
 fun DrawScreenTopBar(
-    hazeState: HazeState,
     state: DrawScreenState,
+    hazeState: HazeState,
     drawingController: DrawingController,
     canvasSize: IntSize,
-    onUIAction: (DrawScreenUIAction) -> Unit
+    onUIAction: (DrawScreenUIAction) -> Unit,
+    onNavigationEvent: (NavigationEvent) -> Unit
 ) {
 
     TopBar(
@@ -76,7 +60,9 @@ fun DrawScreenTopBar(
         title = { Text(text = stringResource(R.string.app_name)) },
         navigationAction = {
 
-            IconButton(onClick = remember { { drawingController.clear() } }) {
+            IconButton(
+                onClick = remember { { onNavigationEvent(NavigationEvent.NavigateUp) } }
+            ) {
                 Icon(
                     modifier = Modifier.size(28.dp),
                     painter = painterResource(R.drawable.arrow_left_outlined),
@@ -105,87 +91,32 @@ fun DrawScreenTopBar(
                 )
             }
 
-            var exportOffset by remember { mutableStateOf(IntOffset.Zero) }
-            val animated by rememberUpdatedState(
-                drawingController.totalPointCount == drawingController.maxPoints
+            val isGlowVisible by rememberUpdatedState(
+                drawingController.totalPointCount
+                        == DrawingController.MAX_POINTS
             )
 
-            val transition = rememberInfiniteTransition(
-                label = "export-button-transition"
-            )
-
-            val glowOffsetX1 by transition.animateValue(
-                initialValue = 0.dp,
-                targetValue = 0.dp,
-                typeConverter = Dp.VectorConverter,
-                animationSpec = infiniteRepeatable(
-                    animation = keyframes {
-                        (-2).dp at 0
-                        2.dp at 1000
-                        durationMillis = 2000
-                    },
-                    repeatMode = RepeatMode.Reverse
-                )
-
-            )
-
-            val glowOffsetX2 by transition.animateValue(
-                initialValue = 0.dp,
-                targetValue = 0.dp,
-                typeConverter = Dp.VectorConverter,
-                animationSpec = infiniteRepeatable(
-                    animation = keyframes {
-                        2.dp at 0
-                        (-2).dp at 1000
-                        durationMillis = 2000
-                    },
-                    repeatMode = RepeatMode.Reverse
-                )
-
-            )
-
-            val alpha by animateFloatAsState(
-                targetValue = if (animated) 1f else 0f,
-                animationSpec = tween(durationMillis = 360)
-            )
-
-            OutlinedIconButton(
-                modifier = Modifier
-                    .onSizeChanged { exportOffset = it.center }
-                    .defaultAuraGlow(
-                        color = state.drawConfiguration.color,
-                        centerOffset = exportOffset,
-                        glowOffset = glowOffsetX1,
-                        alpha = alpha
-                    )
-                    .defaultAuraGlow(
-                        color = state.drawConfiguration.color,
-                        centerOffset = exportOffset,
-                        glowOffset = glowOffsetX2,
-                        alpha = alpha,
-                        spread = (-1).dp
-                    ),
+            AuraButton(
+                size = 40.dp,
                 onClick = {
                     onUIAction(
                         DrawScreenUIAction.Export(
                             width = canvasSize.width,
-                            height = canvasSize.height
+                            height = canvasSize.height,
+                            messageId = state.messageId
                         )
                     )
                 },
-                colors = IconButtonDefaults.outlinedIconButtonColors(
-                    containerColor = Theme.colors.surfaceElevationHigh,
-                    contentColor = Theme.colors.onSurfaceElevationHigh
-                ),
-                border = BorderStroke(
-                    width = 1.dp,
-                    color = Theme.colors.outline
-                )
+                hazeState = hazeState,
+                isGlowVisible = isGlowVisible,
+                glowColor = state.drawConfiguration.color
             ) {
+
                 Icon(
                     painter = painterResource(R.drawable.export),
                     contentDescription = null
                 )
+
             }
 
         }

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/main/draw_screen/DrawScreenUIAction.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/main/draw_screen/DrawScreenUIAction.kt
@@ -46,7 +46,8 @@ interface DrawScreenUIAction {
 
     data class Export(
         val width: Int,
-        val height: Int
+        val height: Int,
+        val messageId: Long?
     ) : DrawScreenUIAction
 
     data class SetDialogEditType(

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/main/draw_screen/DrawingCanvas.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/main/draw_screen/DrawingCanvas.kt
@@ -51,7 +51,7 @@ fun DrawingCanvas(
 
     ParticleUpdater(
         controller = controller,
-        effect = drawConfiguration.effect
+        brushEffect = drawConfiguration.effect
     )
 
     Canvas(

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/main/draw_screen/dialog/DrawScreenExportDialog.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/main/draw_screen/dialog/DrawScreenExportDialog.kt
@@ -96,7 +96,6 @@ fun DrawScreenExportDialog(
             Column(
                 modifier = Modifier
                     .padding(horizontal = 40.dp)
-                    .fillMaxWidth()
                     .clip(Theme.shapes.mediumShape)
                     .defaultHazeEffect(hazeState = hazeState)
                     .border(

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/main/home_screen/HomeScreen.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/main/home_screen/HomeScreen.kt
@@ -1,0 +1,239 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2025 Stoyan Vuchev
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES, OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.stoyanvuchev.magicmessage.presentation.main.home_screen
+
+import androidx.compose.animation.ExperimentalSharedTransitionApi
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.GridItemSpan
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.itemsIndexed
+import androidx.compose.foundation.lazy.grid.rememberLazyGridState
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.stoyanvuchev.magicmessage.R
+import com.stoyanvuchev.magicmessage.core.ui.components.top_bar.TopBar
+import com.stoyanvuchev.magicmessage.core.ui.effect.defaultHazeEffect
+import com.stoyanvuchev.magicmessage.core.ui.event.NavigationEvent
+import com.stoyanvuchev.magicmessage.core.ui.theme.Theme
+import dev.chrisbanes.haze.hazeSource
+import dev.chrisbanes.haze.rememberHazeState
+
+@OptIn(ExperimentalSharedTransitionApi::class)
+@Composable
+fun HomeScreen(
+    state: HomeScreenState,
+    onUIAction: (HomeScreenUIAction) -> Unit,
+    onNavigationEvent: (NavigationEvent) -> Unit
+) {
+
+    val lazyGridState = rememberLazyGridState()
+    val hazeState = rememberHazeState()
+
+    Scaffold(
+        modifier = Modifier
+            .fillMaxSize(),
+        containerColor = Theme.colors.surfaceElevationLow,
+        contentColor = Theme.colors.onSurfaceElevationLow,
+        topBar = {
+
+            TopBar(
+                modifier = Modifier.defaultHazeEffect(hazeState = hazeState),
+                title = { Text(text = stringResource(R.string.home_screen_label)) }
+            )
+
+        }
+    ) { innerPadding ->
+
+        LazyVerticalGrid(
+            modifier = Modifier
+                .fillMaxSize()
+                .hazeSource(state = hazeState),
+            contentPadding = innerPadding,
+            state = lazyGridState,
+            columns = GridCells.Fixed(2),
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+
+            if (state.exportedCreationsList.isNotEmpty()) {
+
+                item(
+                    span = { GridItemSpan(this.maxLineSpan) }
+                ) {
+
+                    Spacer(modifier = Modifier.height(12.dp))
+
+                    Text(
+                        modifier = Modifier
+                            .padding(horizontal = 24.dp)
+                            .padding(top = 24.dp)
+                            .animateItem(),
+                        text = stringResource(R.string.home_screen_exported_label),
+                        style = Theme.typefaces.bodySmall,
+                        color = Theme.colors.onSurfaceElevationLow.copy(.5f)
+                    )
+
+                    Spacer(modifier = Modifier.height(0.dp))
+
+                }
+
+                itemsIndexed(
+                    items = state.exportedCreationsList,
+                    key = { _, creation -> "exported_item_${creation.createdAt}" }
+                ) { i, creation ->
+
+                    val startPadding by remember(i) {
+                        derivedStateOf { if (i % 2 == 0) 24.dp else 0.dp }
+                    }
+
+                    val endPadding by remember(i) {
+                        derivedStateOf { if (i % 2 == 0) 0.dp else 24.dp }
+                    }
+
+                    HomeScreenCreationItem(
+                        modifier = Modifier
+                            .padding(
+                                start = startPadding,
+                                end = endPadding
+                            )
+                            .animateItem(),
+                        creation = creation,
+                        onNavigationEvent = onNavigationEvent,
+                        onLongClick = remember { {} }
+                    )
+
+                }
+
+            }
+
+            if (state.draftedCreationsList.isNotEmpty()) {
+
+                item(
+                    span = { GridItemSpan(this.maxLineSpan) }
+                ) {
+
+                    Spacer(modifier = Modifier.height(12.dp))
+
+                    Text(
+                        modifier = Modifier
+                            .padding(horizontal = 24.dp)
+                            .padding(top = 24.dp)
+                            .animateItem(),
+                        text = stringResource(R.string.home_screen_drafted_label),
+                        style = Theme.typefaces.bodySmall,
+                        color = Theme.colors.onSurfaceElevationLow.copy(.5f)
+                    )
+
+                    Spacer(modifier = Modifier.height(0.dp))
+
+                }
+
+                itemsIndexed(
+                    items = state.draftedCreationsList,
+                    key = { _, creation -> "drafted_item_${creation.createdAt}" }
+                ) { i, creation ->
+
+                    val startPadding by remember(i) {
+                        derivedStateOf { if (i % 2 == 0) 24.dp else 0.dp }
+                    }
+
+                    val endPadding by remember(i) {
+                        derivedStateOf { if (i % 2 == 0) 0.dp else 24.dp }
+                    }
+
+                    HomeScreenCreationItem(
+                        modifier = Modifier
+                            .padding(
+                                start = startPadding,
+                                end = endPadding
+                            )
+                            .animateItem(),
+                        creation = creation,
+                        onNavigationEvent = onNavigationEvent,
+                        onLongClick = remember { {} }
+                    )
+
+                }
+
+            }
+
+            item(
+                span = { GridItemSpan(this.maxLineSpan) }
+            ) {
+                Spacer(modifier = Modifier.height(164.dp))
+            }
+
+        }
+
+    }
+
+    if (state.exportedCreationsList.isEmpty() && state.draftedCreationsList.isEmpty()) {
+
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .windowInsetsPadding(WindowInsets.safeDrawing)
+                .padding(bottom = 80.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(24.dp, Alignment.CenterVertically)
+        ) {
+
+            Icon(
+                modifier = Modifier.size(100.dp),
+                painter = painterResource(R.drawable.logo_icon),
+                contentDescription = null
+            )
+
+            Text(
+                text = stringResource(R.string.home_screen_empty_text),
+                style = Theme.typefaces.bodyLarge,
+                color = Theme.colors.onSurfaceElevationLow.copy(.5f)
+            )
+
+        }
+
+    }
+
+}

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/main/home_screen/HomeScreenCreationItem.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/main/home_screen/HomeScreenCreationItem.kt
@@ -1,0 +1,127 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2025 Stoyan Vuchev
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES, OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.stoyanvuchev.magicmessage.presentation.main.home_screen
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.drawscope.scale
+import androidx.compose.ui.semantics.Role
+import com.stoyanvuchev.magicmessage.core.ui.components.interaction.rememberRipple
+import com.stoyanvuchev.magicmessage.core.ui.event.NavigationEvent
+import com.stoyanvuchev.magicmessage.core.ui.ext.drawStroke
+import com.stoyanvuchev.magicmessage.core.ui.theme.Theme
+import com.stoyanvuchev.magicmessage.domain.layer.BackgroundLayer
+import com.stoyanvuchev.magicmessage.domain.model.CreationModel
+import com.stoyanvuchev.magicmessage.presentation.main.MainScreen
+
+@Composable
+fun HomeScreenCreationItem(
+    modifier: Modifier = Modifier,
+    creation: CreationModel,
+    onNavigationEvent: (NavigationEvent) -> Unit,
+    onLongClick: () -> Unit
+) {
+
+    Canvas(
+        modifier = modifier
+            .combinedClickable(
+                onClick = remember(creation.id) {
+                    {
+                        onNavigationEvent(
+                            NavigationEvent.NavigateTo(
+                                MainScreen.Draw(creation.id)
+                            )
+                        )
+                    }
+                },
+                onLongClick = onLongClick,
+                interactionSource = remember { MutableInteractionSource() },
+                indication = rememberRipple(),
+                role = Role.Image
+            )
+            .fillMaxWidth()
+            .aspectRatio(1f)
+            .clip(shape = Theme.shapes.smallShape)
+            .background(color = Theme.colors.surfaceElevationHigh)
+    ) {
+
+        // Draw the background layer.
+        when (creation.drawConfiguration.bgLayer) {
+
+            is BackgroundLayer.ColorLayer -> {
+
+                drawRect(
+                    color = creation.drawConfiguration.bgLayer.color,
+                    size = size
+                )
+
+            }
+
+            is BackgroundLayer.LinearGradientLayer -> {
+
+                val brush = Brush.linearGradient(
+                    colors = creation.drawConfiguration.bgLayer.colors,
+                    start = creation.drawConfiguration.bgLayer.start,
+                    end = creation.drawConfiguration.bgLayer.end ?: Offset.Infinite
+                )
+
+                drawRect(
+                    brush = brush,
+                    size = size
+                )
+
+            }
+
+            else -> Unit
+
+        }
+
+        scale(
+            scaleX = .33f,
+            scaleY = .33f,
+            pivot = this.center.copy(
+                x = this.center.x / 2,
+                y = this.center.y / 8
+            )
+        ) {
+
+            // Draw completed strokes.
+            creation.drawingSnapshot.strokes.forEach { drawStroke(it) }
+
+        }
+
+    }
+
+}

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/main/home_screen/HomeScreenState.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/main/home_screen/HomeScreenState.kt
@@ -22,15 +22,13 @@
  * SOFTWARE.
  */
 
-package com.stoyanvuchev.magicmessage.presentation.main.draw_screen
+package com.stoyanvuchev.magicmessage.presentation.main.home_screen
 
 import androidx.compose.runtime.Stable
-import com.stoyanvuchev.magicmessage.domain.model.DrawConfiguration
-import com.stoyanvuchev.magicmessage.presentation.main.draw_screen.dialog.DialogEditType
+import com.stoyanvuchev.magicmessage.domain.model.CreationModel
 
 @Stable
-data class DrawScreenState(
-    val messageId: Long? = null,
-    val dialogEditType: DialogEditType = DialogEditType.NONE,
-    val drawConfiguration: DrawConfiguration = DrawConfiguration()
+data class HomeScreenState(
+    val exportedCreationsList: List<CreationModel> = emptyList(),
+    val draftedCreationsList: List<CreationModel> = emptyList()
 )

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/main/home_screen/HomeScreenUIAction.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/main/home_screen/HomeScreenUIAction.kt
@@ -22,15 +22,13 @@
  * SOFTWARE.
  */
 
-package com.stoyanvuchev.magicmessage.presentation.main.draw_screen
+package com.stoyanvuchev.magicmessage.presentation.main.home_screen
 
-import androidx.compose.runtime.Stable
-import com.stoyanvuchev.magicmessage.domain.model.DrawConfiguration
-import com.stoyanvuchev.magicmessage.presentation.main.draw_screen.dialog.DialogEditType
+import androidx.compose.runtime.Immutable
 
-@Stable
-data class DrawScreenState(
-    val messageId: Long? = null,
-    val dialogEditType: DialogEditType = DialogEditType.NONE,
-    val drawConfiguration: DrawConfiguration = DrawConfiguration()
-)
+@Immutable
+interface HomeScreenUIAction {
+
+    data object NewMessage : HomeScreenUIAction
+
+}

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/main/home_screen/HomeScreenViewModel.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/main/home_screen/HomeScreenViewModel.kt
@@ -1,0 +1,86 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2025 Stoyan Vuchev
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES, OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.stoyanvuchev.magicmessage.presentation.main.home_screen
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.stoyanvuchev.magicmessage.core.ui.event.NavigationEvent
+import com.stoyanvuchev.magicmessage.domain.usecase.CreationUseCases
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class HomeScreenViewModel @Inject constructor(
+    useCases: CreationUseCases
+) : ViewModel() {
+
+    val state: StateFlow<HomeScreenState> = combine(
+        flow = useCases.getExportedUseCase(),
+        flow2 = useCases.getDraftsUseCase()
+    ) { exported, drafted ->
+
+        HomeScreenState(
+            exportedCreationsList = exported,
+            draftedCreationsList = drafted
+        )
+
+    }.stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(5_000),
+        initialValue = HomeScreenState()
+    )
+
+    private val _uiActionChannel = Channel<HomeScreenUIAction>()
+    val uiActionFlow = _uiActionChannel.receiveAsFlow()
+
+    private val _navigationChannel = Channel<NavigationEvent>()
+    val navigationFlow = _navigationChannel.receiveAsFlow()
+
+    fun onUIAction(action: HomeScreenUIAction) {
+        when (action) {
+            is HomeScreenUIAction.NewMessage -> sendUIAction(action)
+        }
+    }
+
+    fun onNavigationEvent(event: NavigationEvent) {
+        sendNavigationEvent(event)
+    }
+
+    private fun sendUIAction(action: HomeScreenUIAction) {
+        viewModelScope.launch { _uiActionChannel.send(action) }
+    }
+
+    private fun sendNavigationEvent(event: NavigationEvent) {
+        viewModelScope.launch { _navigationChannel.send(event) }
+    }
+
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -34,4 +34,7 @@
     <string name="exporter_label_completed_description">"Enjoy the GIF 🎉"</string>
     <string name="exporter_label_view">View</string>
     <string name="exporter_label_cancel">Cancel</string>
+    <string name="home_screen_exported_label">Exported</string>
+    <string name="home_screen_drafted_label">Drafts</string>
+    <string name="home_screen_empty_text">Tap the pen icon\nto draw something.</string>
 </resources>

--- a/app/src/test/java/com/stoyanvuchev/magicmessage/core/ui/DrawingControllerTest.kt
+++ b/app/src/test/java/com/stoyanvuchev/magicmessage/core/ui/DrawingControllerTest.kt
@@ -74,7 +74,7 @@ class DrawingControllerTest {
     @Test
     fun `exceeding maxPoints disables drawing`() {
         // Fill up to the limit
-        repeat(controller.maxPoints) {
+        repeat(DrawingController.MAX_POINTS) {
             controller.startStroke(Offset(it.toFloat(), 0f), Color.Black, BrushEffect.NONE)
             controller.addPoint(Offset(it.toFloat(), 1f), Color.Black, BrushEffect.NONE)
             controller.endStroke(Color.Black, 2f, BrushEffect.NONE)


### PR DESCRIPTION
This commit introduces significant changes to how drawing state is managed and saved, implements a new HomeScreen to display drafts and exported creations, and refines UI components.

**Key Changes:**

- **`DrawingSnapshot` Model:**
    - Introduced `DrawingSnapshot.kt` to encapsulate the entire state of a drawing (strokes, current points, undo/redo stacks, etc.). This model is serializable.

- **`DrawingController` Refactor:**
    - `DrawingController.kt` now uses `DrawingSnapshot` for saving and restoring its state.
    - Added `snapshot()` method to create a `DrawingSnapshot` and a companion object function `fromSnapshot()` to restore the controller from a snapshot.
    - Particle management (`particlesInternal`, `syncParticlesToUI`) was refined.
    - `MAX_POINTS` is now a public constant.
    - Clearing undo/redo now also clears particles.

- **HomeScreen Implementation:**
    - Added `HomeScreen.kt`, `HomeScreenState.kt`, `HomeScreenViewModel.kt`, and `HomeScreenUIAction.kt`.
    - `HomeScreen` displays lists of "Exported" and "Drafted" creations in a `LazyVerticalGrid`.
    - It features a `TopBar` with a haze effect and an empty state message when no creations exist.
    - `HomeScreenCreationItem.kt` is a new composable to display individual creation previews. It renders a scaled-down version of the drawing.
    - Navigation from `HomeScreen` to `DrawScreen` is implemented.

- **Data Layer & Repository Updates:**
    - `CreationEntity.kt` now stores `DrawingSnapshot` instead of a list of `StrokeModel`.
    - `CreationRepository.kt` and `CreationRepositoryImpl.kt` were updated to handle `DrawingSnapshot`.
        - `saveOrUpdateDraft` now takes `DrawingSnapshot`.
        - `markAsFinished` no longer takes `previewUri`. - `getDrafts()` and `getFinished()` now return `Flow<List<CreationModel>>`.
    - `CreationDao.kt` queries updated for `isDraft` boolean (was integer).
    - `CreationTypeConverters.kt` added converters for `DrawingSnapshot`.
    - New use cases: `CreationGetDraftsUseCase.kt`, `CreationGetExportedUseCase.kt`, `CreationMarkAsExportedUseCase.kt`. These are integrated into `CreationUseCases.kt` and `CreationModule.kt`.

- **UI & Component Enhancements:**
    - **`AuraButton.kt`:** A new reusable button component with a configurable animated aura/glow effect and haze background.
    - **`DrawScreenTopBar.kt`:**
        - Replaced the export `OutlinedIconButton` with the new `AuraButton`.
        - Navigation back from `DrawScreen` now goes to `HomeScreen` and saves the current draft.
    - **`AppBottomNavBar.kt`:** - Added an `AuraButton` (pencil icon) centered above the bottom navigation bar when on `HomeScreen`, allowing users to start a new drawing. This button is animated.
    - **`DefaultAuraGlow.kt`:** Refactored into `outerAuraGlow` and introduced `innerAuraGlow` modifier for more flexible glow effects.
    - `DrawScreen.kt`: Now receives `onNavigationEvent` and updates progress bar based on `DrawingController.MAX_POINTS`.
    - `NavigationEvent.kt` is now a `sealed interface`.
    - `ParticleUpdater.kt`: `LaunchedEffect` dependencies updated.
    - Haze effect tint slightly adjusted in `DefaultHazeEffect.kt`.

- **Serialization:**
    - Added several new serializer classes: - `SnapshotStateListSerializer.kt` - `AnyAsStringSerializer.kt` - `ArrayDequeSerializer.kt` - `SerializerCollection.kt` (provides typed serializers for lists and deques of domain models).
    - `Particle.kt` is now `@Serializable`.

- **State Management & Navigation:**
    - `DrawScreenState.kt` now includes `messageId`.
    - `DrawScreenViewModel.kt`:
        - Handles saving drafts when navigating away.
        - Loads drafts based on `messageId`. - Manages navigation events via `_navigationEventChannel`.
    - `MainNavGraph.kt`: - `HomeScreen` is now the start destination for the main navigation graph. - Navigation logic updated to handle draft saving and navigation between `HomeScreen` and `DrawScreen`. - `ExportGifService` intent now includes `messageId` to mark the correct creation as exported.
    - `AppNavHost.kt`: Default navigation after onboarding now goes to `HomeScreen`.
    - `MainScreen.kt`: `Draw` screen route parameter `messageId` is now nullable.

- **String Resources:**
    - Added new strings for HomeScreen labels and empty state text.

- **Testing:**
    - Updated `CreationRepositoryTest.kt` and `CreationDatabaseTest.kt` to align with the new data structures and repository methods.
    - `DrawingControllerTest.kt` updated to use `DrawingController.MAX_POINTS`.

- **Minor Changes:**
    - `ExportGifService.kt`: Now uses `CreationUseCases` to mark a message as exported.
    - `Particle.kt`: Properties are now serializable.
    - Updated deployment target in `.idea/deploymentTargetSelector.xml`.