### PR TITLE
Implemented screen transitions and placeholders.

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -4,10 +4,10 @@
     <selectionStates>
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
-        <DropdownSelection timestamp="2025-09-21T09:29:31.712906Z">
+        <DropdownSelection timestamp="2025-09-21T15:17:19.396497Z">
           <Target type="DEFAULT_BOOT">
             <handle>
-              <DeviceId pluginId="LocalEmulator" identifier="path=/Users/stoyan/.android/avd/Pixel_6_Pro.avd" />
+              <DeviceId pluginId="PhysicalDevice" identifier="serial=R5CX22P8R0T" />
             </handle>
           </Target>
         </DropdownSelection>

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/core/ui/transition/DefaultNavigationTransitions.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/core/ui/transition/DefaultNavigationTransitions.kt
@@ -1,0 +1,77 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2025 Stoyan Vuchev
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES, OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.stoyanvuchev.magicmessage.core.ui.transition
+
+import androidx.compose.animation.AnimatedContentTransitionScope
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.ExitTransition
+import androidx.compose.runtime.Stable
+import androidx.navigation.NavBackStackEntry
+import com.stoyanvuchev.magicmessage.core.ui.navigation.NavigationScreen
+
+@Stable
+object DefaultNavigationTransitions : NavigationTransitions {
+
+    override fun enter(
+        scope: AnimatedContentTransitionScope<NavBackStackEntry>,
+        initialRoute: NavigationScreen?,
+        targetRoute: NavigationScreen?
+    ): EnterTransition {
+        return DefaultTransitions.Enter.fadeInWithScaleIn(
+            initialScale = DefaultTransitions.INITIAL_SCALE
+        )
+    }
+
+    override fun exit(
+        scope: AnimatedContentTransitionScope<NavBackStackEntry>,
+        initialRoute: NavigationScreen?,
+        targetRoute: NavigationScreen?
+    ): ExitTransition {
+        return DefaultTransitions.Exit.fadeOutWithScaleOut(
+            targetScale = DefaultTransitions.TARGET_SCALE
+        )
+    }
+
+    override fun popEnter(
+        scope: AnimatedContentTransitionScope<NavBackStackEntry>,
+        initialRoute: NavigationScreen?,
+        targetRoute: NavigationScreen?
+    ): EnterTransition {
+        return DefaultTransitions.Enter.fadeInWithScaleIn(
+            initialScale = DefaultTransitions.INITIAL_POP_SCALE
+        )
+    }
+
+    override fun popExit(
+        scope: AnimatedContentTransitionScope<NavBackStackEntry>,
+        initialRoute: NavigationScreen?,
+        targetRoute: NavigationScreen?
+    ): ExitTransition {
+        return DefaultTransitions.Exit.fadeOutWithScaleOut(
+            targetScale = DefaultTransitions.TARGET_POP_SCALE
+        )
+    }
+
+}

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/core/ui/transition/DefaultTransitions.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/core/ui/transition/DefaultTransitions.kt
@@ -1,0 +1,127 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2025 Stoyan Vuchev
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES, OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.stoyanvuchev.magicmessage.core.ui.transition
+
+import androidx.compose.animation.AnimatedContentTransitionScope
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.ExitTransition
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.spring
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.scaleIn
+import androidx.compose.animation.scaleOut
+import androidx.compose.runtime.Stable
+import androidx.navigation.NavBackStackEntry
+
+@Stable
+object DefaultTransitions {
+
+    const val INITIAL_SCALE = .9f
+    const val INITIAL_POP_SCALE = 1.1f
+    const val TARGET_SCALE = 1.1f
+    const val TARGET_POP_SCALE = .9f
+
+    @Stable
+    object Enter {
+
+        fun fadeInWithScaleIn(
+            initialScale: Float
+        ): EnterTransition {
+            return fadeIn(
+                spring(
+                    dampingRatio = Spring.DampingRatioNoBouncy,
+                    stiffness = Spring.StiffnessMedium
+                )
+            ) + scaleIn(
+                initialScale = initialScale,
+                animationSpec = spring(
+                    dampingRatio = Spring.DampingRatioLowBouncy,
+                    stiffness = Spring.StiffnessMediumLow
+                )
+            )
+        }
+
+        fun slideIntoContainerAndFadeIn(
+            scope: AnimatedContentTransitionScope<NavBackStackEntry>,
+            slideDirection: AnimatedContentTransitionScope.SlideDirection,
+            initialOffset: (Int) -> Int = { it }
+        ): EnterTransition {
+            return with(scope) {
+                fadeIn(
+                    spring(
+                        dampingRatio = Spring.DampingRatioNoBouncy,
+                        stiffness = Spring.StiffnessMedium
+                    )
+                ) + slideIntoContainer(
+                    towards = slideDirection,
+                    initialOffset = initialOffset
+                )
+            }
+        }
+
+    }
+
+    @Stable
+    object Exit {
+
+        fun fadeOutWithScaleOut(
+            targetScale: Float
+        ): ExitTransition {
+            return fadeOut(
+                spring(
+                    dampingRatio = Spring.DampingRatioNoBouncy,
+                    stiffness = Spring.StiffnessMedium
+                )
+            ) + scaleOut(
+                targetScale = targetScale,
+                animationSpec = spring(
+                    dampingRatio = Spring.DampingRatioLowBouncy,
+                    stiffness = Spring.StiffnessMediumLow
+                )
+            )
+        }
+
+        fun slideOutOfContainerAndFadeOut(
+            scope: AnimatedContentTransitionScope<NavBackStackEntry>,
+            slideDirection: AnimatedContentTransitionScope.SlideDirection,
+            targetOffset: (Int) -> Int = { it }
+        ): ExitTransition {
+            return with(scope) {
+                fadeOut(
+                    spring(
+                        dampingRatio = Spring.DampingRatioNoBouncy,
+                        stiffness = Spring.StiffnessMedium
+                    )
+                ) + slideOutOfContainer(
+                    towards = slideDirection,
+                    targetOffset = targetOffset
+                )
+            }
+        }
+
+    }
+
+}

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/core/ui/transition/NavigationTransitions.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/core/ui/transition/NavigationTransitions.kt
@@ -1,0 +1,61 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2025 Stoyan Vuchev
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES, OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.stoyanvuchev.magicmessage.core.ui.transition
+
+import androidx.compose.animation.AnimatedContentTransitionScope
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.ExitTransition
+import androidx.compose.runtime.Stable
+import androidx.navigation.NavBackStackEntry
+import com.stoyanvuchev.magicmessage.core.ui.navigation.NavigationScreen
+
+@Stable
+interface NavigationTransitions {
+
+    fun enter(
+        scope: AnimatedContentTransitionScope<NavBackStackEntry>,
+        initialRoute: NavigationScreen? = null,
+        targetRoute: NavigationScreen? = null
+    ): EnterTransition
+
+    fun exit(
+        scope: AnimatedContentTransitionScope<NavBackStackEntry>,
+        initialRoute: NavigationScreen? = null,
+        targetRoute: NavigationScreen? = null
+    ): ExitTransition
+
+    fun popEnter(
+        scope: AnimatedContentTransitionScope<NavBackStackEntry>,
+        initialRoute: NavigationScreen? = null,
+        targetRoute: NavigationScreen? = null
+    ): EnterTransition
+
+    fun popExit(
+        scope: AnimatedContentTransitionScope<NavBackStackEntry>,
+        initialRoute: NavigationScreen? = null,
+        targetRoute: NavigationScreen? = null
+    ): ExitTransition
+
+}

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/AppBottomNavBar.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/AppBottomNavBar.kt
@@ -48,6 +48,7 @@ import androidx.navigation.compose.currentBackStackEntryAsState
 import com.stoyanvuchev.magicmessage.core.ui.components.bottom_nav_bar.BottomNavBar
 import com.stoyanvuchev.magicmessage.core.ui.components.bottom_nav_bar.BottomNavBarItem
 import com.stoyanvuchev.magicmessage.core.ui.effect.defaultHazeEffect
+import com.stoyanvuchev.magicmessage.presentation.main.MainScreen
 import com.stoyanvuchev.magicmessage.presentation.main.mainScreenNavDestinations
 import dev.chrisbanes.haze.HazeState
 
@@ -97,7 +98,16 @@ fun AppBottomNavBar(
 
                 BottomNavBarItem(
                     selected = selected,
-                    onClick = { navController.navigate(destination) },
+                    onClick = {
+                        if (!selected) {
+                            navController.navigate(destination) {
+                                launchSingleTop = true
+                                popUpTo(MainScreen.Home) {
+                                    inclusive = false
+                                }
+                            }
+                        }
+                    },
                     icon = { offsetY ->
 
                         Icon(

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/AppNavHost.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/AppNavHost.kt
@@ -34,6 +34,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
@@ -41,6 +42,7 @@ import androidx.navigation.compose.composable
 import com.stoyanvuchev.magicmessage.core.ui.animation.LocalAnimatedContentScope
 import com.stoyanvuchev.magicmessage.core.ui.navigation.InitialScreen
 import com.stoyanvuchev.magicmessage.core.ui.theme.Theme
+import com.stoyanvuchev.magicmessage.core.ui.transition.DefaultNavigationTransitions
 import com.stoyanvuchev.magicmessage.core.ui.transition.LocalSharedTransitionScope
 import com.stoyanvuchev.magicmessage.framework.export.ExporterState
 import com.stoyanvuchev.magicmessage.presentation.boarding.BoardingScreen
@@ -95,6 +97,10 @@ fun AppNavHost(
                     modifier = Modifier
                         .fillMaxSize()
                         .hazeSource(state = hazeState),
+                    enterTransition = remember { { DefaultNavigationTransitions.enter(this) } },
+                    exitTransition = remember { { DefaultNavigationTransitions.exit(this) } },
+                    popEnterTransition = remember { { DefaultNavigationTransitions.popEnter(this) } },
+                    popExitTransition = remember { { DefaultNavigationTransitions.popExit(this) } },
                     navController = navController,
                     startDestination = InitialScreen
                 ) {

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/main/MainNavGraph.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/main/MainNavGraph.kt
@@ -26,16 +26,25 @@ package com.stoyanvuchev.magicmessage.presentation.main
 
 import android.content.Intent
 import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.systemBarsPadding
+import androidx.compose.material3.Text
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.composable
 import androidx.navigation.navigation
+import com.stoyanvuchev.magicmessage.R
 import com.stoyanvuchev.magicmessage.core.ui.event.NavigationEvent
+import com.stoyanvuchev.magicmessage.core.ui.theme.Theme
 import com.stoyanvuchev.magicmessage.framework.service.ExportGifService
 import com.stoyanvuchev.magicmessage.presentation.main.draw_screen.DrawScreen
 import com.stoyanvuchev.magicmessage.presentation.main.draw_screen.DrawScreenUIAction
@@ -43,6 +52,10 @@ import com.stoyanvuchev.magicmessage.presentation.main.draw_screen.DrawScreenVie
 import com.stoyanvuchev.magicmessage.presentation.main.home_screen.HomeScreen
 import com.stoyanvuchev.magicmessage.presentation.main.home_screen.HomeScreenUIAction
 import com.stoyanvuchev.magicmessage.presentation.main.home_screen.HomeScreenViewModel
+import com.stoyanvuchev.magicmessage.presentation.main.transitions.FavoriteNavigationTransitions
+import com.stoyanvuchev.magicmessage.presentation.main.transitions.HomeNavigationTransitions
+import com.stoyanvuchev.magicmessage.presentation.main.transitions.MenuNavigationTransitions
+import com.stoyanvuchev.magicmessage.presentation.main.transitions.safeRoute
 import kotlinx.coroutines.flow.collectLatest
 
 fun NavGraphBuilder.mainNavGraph(navController: NavHostController) {
@@ -51,7 +64,36 @@ fun NavGraphBuilder.mainNavGraph(navController: NavHostController) {
         startDestination = MainScreen.Home
     ) {
 
-        composable<MainScreen.Home> {
+        composable<MainScreen.Home>(
+            enterTransition = {
+                HomeNavigationTransitions.enter(
+                    scope = this,
+                    initialRoute = initialState.safeRoute(),
+                    targetRoute = targetState.safeRoute()
+                )
+            },
+            exitTransition = {
+                HomeNavigationTransitions.exit(
+                    scope = this,
+                    initialRoute = initialState.safeRoute(),
+                    targetRoute = targetState.safeRoute()
+                )
+            },
+            popEnterTransition = {
+                HomeNavigationTransitions.popEnter(
+                    scope = this,
+                    initialRoute = initialState.safeRoute(),
+                    targetRoute = targetState.safeRoute()
+                )
+            },
+            popExitTransition = {
+                HomeNavigationTransitions.popExit(
+                    scope = this,
+                    initialRoute = initialState.safeRoute(),
+                    targetRoute = targetState.safeRoute()
+                )
+            }
+        ) {
 
             val viewModel = hiltViewModel<HomeScreenViewModel>()
             val state by viewModel.state.collectAsStateWithLifecycle()
@@ -104,9 +146,101 @@ fun NavGraphBuilder.mainNavGraph(navController: NavHostController) {
 
     }
 
-    composable<MainScreen.Favorite> {}
+    composable<MainScreen.Favorite>(
+        enterTransition = {
+            FavoriteNavigationTransitions.enter(
+                scope = this,
+                initialRoute = initialState.safeRoute(),
+                targetRoute = targetState.safeRoute()
+            )
+        },
+        exitTransition = {
+            FavoriteNavigationTransitions.exit(
+                scope = this,
+                initialRoute = initialState.safeRoute(),
+                targetRoute = targetState.safeRoute()
+            )
+        },
+        popEnterTransition = {
+            FavoriteNavigationTransitions.popEnter(
+                scope = this,
+                initialRoute = initialState.safeRoute(),
+                targetRoute = targetState.safeRoute()
+            )
+        },
+        popExitTransition = {
+            FavoriteNavigationTransitions.popExit(
+                scope = this,
+                initialRoute = initialState.safeRoute(),
+                targetRoute = targetState.safeRoute()
+            )
+        }
+    ) {
 
-    composable<MainScreen.Menu> {}
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .systemBarsPadding(),
+            contentAlignment = Alignment.Center
+        ) {
+
+            Text(
+                text = stringResource(R.string.favorite_screen_label),
+                style = Theme.typefaces.titleMedium,
+                color = Theme.colors.onSurfaceElevationLow
+            )
+
+        }
+
+    }
+
+    composable<MainScreen.Menu>(
+        enterTransition = {
+            MenuNavigationTransitions.enter(
+                scope = this,
+                initialRoute = initialState.safeRoute(),
+                targetRoute = targetState.safeRoute()
+            )
+        },
+        exitTransition = {
+            MenuNavigationTransitions.exit(
+                scope = this,
+                initialRoute = initialState.safeRoute(),
+                targetRoute = targetState.safeRoute()
+            )
+        },
+        popEnterTransition = {
+            MenuNavigationTransitions.popEnter(
+                scope = this,
+                initialRoute = initialState.safeRoute(),
+                targetRoute = targetState.safeRoute()
+            )
+        },
+        popExitTransition = {
+            MenuNavigationTransitions.popExit(
+                scope = this,
+                initialRoute = initialState.safeRoute(),
+                targetRoute = targetState.safeRoute()
+            )
+        }
+    ) {
+
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .systemBarsPadding(),
+            contentAlignment = Alignment.Center
+        ) {
+
+            Text(
+                text = stringResource(R.string.menu_screen_label),
+                style = Theme.typefaces.titleMedium,
+                color = Theme.colors.onSurfaceElevationLow
+            )
+
+        }
+
+    }
 
     composable<MainScreen.Draw> {
 
@@ -146,12 +280,7 @@ fun NavGraphBuilder.mainNavGraph(navController: NavHostController) {
                 when (event) {
 
                     is NavigationEvent.NavigateUp -> {
-                        navController.navigate(MainScreen.Home) {
-                            popUpTo(navController.graph.id) {
-                                inclusive = false
-                            }
-                            launchSingleTop = true
-                        }
+                        navController.navigateUp()
                     }
 
                     else -> Unit

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/main/transitions/FavoriteNavigationTransitions.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/main/transitions/FavoriteNavigationTransitions.kt
@@ -1,0 +1,152 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2025 Stoyan Vuchev
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES, OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.stoyanvuchev.magicmessage.presentation.main.transitions
+
+import androidx.compose.animation.AnimatedContentTransitionScope
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.ExitTransition
+import androidx.compose.runtime.Stable
+import androidx.navigation.NavBackStackEntry
+import com.stoyanvuchev.magicmessage.core.ui.navigation.NavigationScreen
+import com.stoyanvuchev.magicmessage.core.ui.transition.DefaultTransitions
+import com.stoyanvuchev.magicmessage.core.ui.transition.NavigationTransitions
+import com.stoyanvuchev.magicmessage.presentation.main.MainScreen
+
+@Stable
+object FavoriteNavigationTransitions : NavigationTransitions {
+
+    override fun enter(
+        scope: AnimatedContentTransitionScope<NavBackStackEntry>,
+        initialRoute: NavigationScreen?,
+        targetRoute: NavigationScreen?
+    ): EnterTransition {
+        return when {
+
+            initialRoute is MainScreen.Home && targetRoute is MainScreen.Favorite -> {
+                DefaultTransitions.Enter.slideIntoContainerAndFadeIn(
+                    scope = scope,
+                    slideDirection = AnimatedContentTransitionScope.SlideDirection.Start
+                )
+            }
+
+            initialRoute is MainScreen.Menu && targetRoute is MainScreen.Favorite -> {
+                DefaultTransitions.Enter.slideIntoContainerAndFadeIn(
+                    scope = scope,
+                    slideDirection = AnimatedContentTransitionScope.SlideDirection.End
+                )
+            }
+
+            else -> DefaultTransitions.Enter.fadeInWithScaleIn(
+                initialScale = DefaultTransitions.INITIAL_SCALE
+            )
+
+        }
+    }
+
+    override fun exit(
+        scope: AnimatedContentTransitionScope<NavBackStackEntry>,
+        initialRoute: NavigationScreen?,
+        targetRoute: NavigationScreen?
+    ): ExitTransition {
+        return when {
+
+            initialRoute is MainScreen.Favorite && targetRoute is MainScreen.Home -> {
+                DefaultTransitions.Exit.slideOutOfContainerAndFadeOut(
+                    scope = scope,
+                    slideDirection = AnimatedContentTransitionScope.SlideDirection.End
+                )
+            }
+
+            initialRoute is MainScreen.Favorite && targetRoute is MainScreen.Menu -> {
+                DefaultTransitions.Exit.slideOutOfContainerAndFadeOut(
+                    scope = scope,
+                    slideDirection = AnimatedContentTransitionScope.SlideDirection.Start
+                )
+            }
+
+            else -> DefaultTransitions.Exit.fadeOutWithScaleOut(
+                targetScale = DefaultTransitions.TARGET_SCALE
+            )
+
+        }
+    }
+
+    override fun popEnter(
+        scope: AnimatedContentTransitionScope<NavBackStackEntry>,
+        initialRoute: NavigationScreen?,
+        targetRoute: NavigationScreen?
+    ): EnterTransition {
+        return when {
+
+            initialRoute is MainScreen.Home && targetRoute is MainScreen.Favorite -> {
+                DefaultTransitions.Enter.slideIntoContainerAndFadeIn(
+                    scope = scope,
+                    slideDirection = AnimatedContentTransitionScope.SlideDirection.Start
+                )
+            }
+
+            initialRoute is MainScreen.Menu && targetRoute is MainScreen.Favorite -> {
+                DefaultTransitions.Enter.slideIntoContainerAndFadeIn(
+                    scope = scope,
+                    slideDirection = AnimatedContentTransitionScope.SlideDirection.End
+                )
+            }
+
+            else -> DefaultTransitions.Enter.fadeInWithScaleIn(
+                initialScale = DefaultTransitions.INITIAL_POP_SCALE
+            )
+
+        }
+    }
+
+    override fun popExit(
+        scope: AnimatedContentTransitionScope<NavBackStackEntry>,
+        initialRoute: NavigationScreen?,
+        targetRoute: NavigationScreen?
+    ): ExitTransition {
+        return when {
+
+            initialRoute is MainScreen.Favorite && targetRoute is MainScreen.Home -> {
+                DefaultTransitions.Exit.slideOutOfContainerAndFadeOut(
+                    scope = scope,
+                    slideDirection = AnimatedContentTransitionScope.SlideDirection.End
+                )
+            }
+
+            initialRoute is MainScreen.Favorite && targetRoute is MainScreen.Menu -> {
+                DefaultTransitions.Exit.slideOutOfContainerAndFadeOut(
+                    scope = scope,
+                    slideDirection = AnimatedContentTransitionScope.SlideDirection.Start
+                )
+            }
+
+            else -> DefaultTransitions.Exit.fadeOutWithScaleOut(
+                targetScale = DefaultTransitions.TARGET_POP_SCALE
+            )
+
+        }
+    }
+
+}

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/main/transitions/HomeNavigationTransitions.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/main/transitions/HomeNavigationTransitions.kt
@@ -1,0 +1,144 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2025 Stoyan Vuchev
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES, OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.stoyanvuchev.magicmessage.presentation.main.transitions
+
+import androidx.compose.animation.AnimatedContentTransitionScope
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.ExitTransition
+import androidx.compose.runtime.Stable
+import androidx.navigation.NavBackStackEntry
+import com.stoyanvuchev.magicmessage.core.ui.navigation.NavigationScreen
+import com.stoyanvuchev.magicmessage.core.ui.transition.DefaultTransitions
+import com.stoyanvuchev.magicmessage.core.ui.transition.NavigationTransitions
+import com.stoyanvuchev.magicmessage.presentation.main.MainScreen
+
+@Stable
+object HomeNavigationTransitions : NavigationTransitions {
+
+    override fun enter(
+        scope: AnimatedContentTransitionScope<NavBackStackEntry>,
+        initialRoute: NavigationScreen?,
+        targetRoute: NavigationScreen?
+    ): EnterTransition {
+        return when {
+
+            initialRoute is MainScreen.Favorite
+                    && targetRoute is MainScreen.Home
+                    || initialRoute is MainScreen.Menu
+                    && targetRoute is MainScreen.Home -> {
+
+                DefaultTransitions.Enter.slideIntoContainerAndFadeIn(
+                    scope = scope,
+                    slideDirection = AnimatedContentTransitionScope.SlideDirection.End
+                )
+
+            }
+
+            else -> DefaultTransitions.Enter.fadeInWithScaleIn(
+                initialScale = DefaultTransitions.INITIAL_SCALE
+            )
+
+        }
+    }
+
+    override fun exit(
+        scope: AnimatedContentTransitionScope<NavBackStackEntry>,
+        initialRoute: NavigationScreen?,
+        targetRoute: NavigationScreen?
+    ): ExitTransition {
+        return when {
+
+            initialRoute is MainScreen.Home
+                    && targetRoute is MainScreen.Favorite
+                    || initialRoute is MainScreen.Home
+                    && targetRoute is MainScreen.Menu -> {
+
+                DefaultTransitions.Exit.slideOutOfContainerAndFadeOut(
+                    scope = scope,
+                    slideDirection = AnimatedContentTransitionScope.SlideDirection.Start
+                )
+
+            }
+
+            else -> DefaultTransitions.Exit.fadeOutWithScaleOut(
+                targetScale = DefaultTransitions.TARGET_SCALE
+            )
+
+        }
+    }
+
+    override fun popEnter(
+        scope: AnimatedContentTransitionScope<NavBackStackEntry>,
+        initialRoute: NavigationScreen?,
+        targetRoute: NavigationScreen?
+    ): EnterTransition {
+        return when {
+
+            initialRoute is MainScreen.Favorite
+                    && targetRoute is MainScreen.Home
+                    || initialRoute is MainScreen.Menu
+                    && targetRoute is MainScreen.Home -> {
+
+                DefaultTransitions.Enter.slideIntoContainerAndFadeIn(
+                    scope = scope,
+                    slideDirection = AnimatedContentTransitionScope.SlideDirection.End
+                )
+
+            }
+
+            else -> DefaultTransitions.Enter.fadeInWithScaleIn(
+                initialScale = DefaultTransitions.INITIAL_POP_SCALE
+            )
+
+        }
+    }
+
+    override fun popExit(
+        scope: AnimatedContentTransitionScope<NavBackStackEntry>,
+        initialRoute: NavigationScreen?,
+        targetRoute: NavigationScreen?
+    ): ExitTransition {
+        return when {
+
+            initialRoute is MainScreen.Home
+                    && targetRoute is MainScreen.Favorite
+                    || initialRoute is MainScreen.Home
+                    && targetRoute is MainScreen.Menu -> {
+
+                DefaultTransitions.Exit.slideOutOfContainerAndFadeOut(
+                    scope = scope,
+                    slideDirection = AnimatedContentTransitionScope.SlideDirection.Start
+                )
+
+            }
+
+            else -> DefaultTransitions.Exit.fadeOutWithScaleOut(
+                targetScale = DefaultTransitions.TARGET_POP_SCALE
+            )
+
+        }
+    }
+
+}

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/main/transitions/MainScreenSafeRoute.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/main/transitions/MainScreenSafeRoute.kt
@@ -1,0 +1,39 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2025 Stoyan Vuchev
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES, OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.stoyanvuchev.magicmessage.presentation.main.transitions
+
+import androidx.navigation.NavBackStackEntry
+import com.stoyanvuchev.magicmessage.core.ui.navigation.NavigationScreen
+import com.stoyanvuchev.magicmessage.presentation.main.MainScreen
+
+fun NavBackStackEntry.safeRoute(): NavigationScreen? {
+    return when (destination.route) {
+        MainScreen.Home::class.qualifiedName -> MainScreen.Home
+        MainScreen.Favorite::class.qualifiedName -> MainScreen.Favorite
+        MainScreen.Menu::class.qualifiedName -> MainScreen.Menu
+        MainScreen.Draw::class.qualifiedName -> MainScreen.Draw(null)
+        else -> null
+    }
+}

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/main/transitions/MenuNavigationTransitions.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/main/transitions/MenuNavigationTransitions.kt
@@ -1,0 +1,144 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2025 Stoyan Vuchev
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES, OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.stoyanvuchev.magicmessage.presentation.main.transitions
+
+import androidx.compose.animation.AnimatedContentTransitionScope
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.ExitTransition
+import androidx.compose.runtime.Stable
+import androidx.navigation.NavBackStackEntry
+import com.stoyanvuchev.magicmessage.core.ui.navigation.NavigationScreen
+import com.stoyanvuchev.magicmessage.core.ui.transition.DefaultTransitions
+import com.stoyanvuchev.magicmessage.core.ui.transition.NavigationTransitions
+import com.stoyanvuchev.magicmessage.presentation.main.MainScreen
+
+@Stable
+object MenuNavigationTransitions : NavigationTransitions {
+
+    override fun enter(
+        scope: AnimatedContentTransitionScope<NavBackStackEntry>,
+        initialRoute: NavigationScreen?,
+        targetRoute: NavigationScreen?
+    ): EnterTransition {
+        return when {
+
+            initialRoute is MainScreen.Home
+                    && targetRoute is MainScreen.Menu
+                    || initialRoute is MainScreen.Favorite
+                    && targetRoute is MainScreen.Menu -> {
+
+                DefaultTransitions.Enter.slideIntoContainerAndFadeIn(
+                    scope = scope,
+                    slideDirection = AnimatedContentTransitionScope.SlideDirection.Start
+                )
+
+            }
+
+            else -> DefaultTransitions.Enter.fadeInWithScaleIn(
+                initialScale = DefaultTransitions.INITIAL_SCALE
+            )
+
+        }
+    }
+
+    override fun exit(
+        scope: AnimatedContentTransitionScope<NavBackStackEntry>,
+        initialRoute: NavigationScreen?,
+        targetRoute: NavigationScreen?
+    ): ExitTransition {
+        return when {
+
+            initialRoute is MainScreen.Menu
+                    && targetRoute is MainScreen.Home
+                    || initialRoute is MainScreen.Menu
+                    && targetRoute is MainScreen.Favorite -> {
+
+                DefaultTransitions.Exit.slideOutOfContainerAndFadeOut(
+                    scope = scope,
+                    slideDirection = AnimatedContentTransitionScope.SlideDirection.End
+                )
+
+            }
+
+            else -> DefaultTransitions.Exit.fadeOutWithScaleOut(
+                targetScale = DefaultTransitions.TARGET_SCALE
+            )
+
+        }
+    }
+
+    override fun popEnter(
+        scope: AnimatedContentTransitionScope<NavBackStackEntry>,
+        initialRoute: NavigationScreen?,
+        targetRoute: NavigationScreen?
+    ): EnterTransition {
+        return when {
+
+            initialRoute is MainScreen.Home
+                    && targetRoute is MainScreen.Menu
+                    || initialRoute is MainScreen.Favorite
+                    && targetRoute is MainScreen.Menu -> {
+
+                DefaultTransitions.Enter.slideIntoContainerAndFadeIn(
+                    scope = scope,
+                    slideDirection = AnimatedContentTransitionScope.SlideDirection.Start
+                )
+
+            }
+
+            else -> DefaultTransitions.Enter.fadeInWithScaleIn(
+                initialScale = DefaultTransitions.INITIAL_POP_SCALE
+            )
+
+        }
+    }
+
+    override fun popExit(
+        scope: AnimatedContentTransitionScope<NavBackStackEntry>,
+        initialRoute: NavigationScreen?,
+        targetRoute: NavigationScreen?
+    ): ExitTransition {
+        return when {
+
+            initialRoute is MainScreen.Menu
+                    && targetRoute is MainScreen.Home
+                    || initialRoute is MainScreen.Menu
+                    && targetRoute is MainScreen.Favorite -> {
+
+                DefaultTransitions.Exit.slideOutOfContainerAndFadeOut(
+                    scope = scope,
+                    slideDirection = AnimatedContentTransitionScope.SlideDirection.End
+                )
+
+            }
+
+            else -> DefaultTransitions.Exit.fadeOutWithScaleOut(
+                targetScale = DefaultTransitions.TARGET_POP_SCALE
+            )
+
+        }
+    }
+
+}


### PR DESCRIPTION
This commit introduces screen transitions for the main navigation graph and adds placeholder content for `FavoriteScreen` and `MenuScreen`.

**Key Changes:**

- **Screen Transitions:**
    - Created `DefaultTransitions.kt` with reusable `EnterTransition` and `ExitTransition` definitions (fadeIn/OutWithScale, slideInto/OutOfContainerAndFadeIn/Out).
    - Created `NavigationTransitions.kt` interface to define standard transition functions (enter, exit, popEnter, popExit).
    - Implemented `DefaultNavigationTransitions.kt` providing default scale and fade transitions.
    - Added specific transition logic for `Home`, `Favorite`, and `Menu` screens in `HomeNavigationTransitions.kt`, `FavoriteNavigationTransitions.kt`, and `MenuNavigationTransitions.kt` respectively. These transitions use sliding and fading based on the source and destination screens.
    - Introduced `MainScreenSafeRoute.kt` to safely convert `NavBackStackEntry` destinations to `NavigationScreen` types for transition logic.
    - Integrated these transitions into `MainNavGraph.kt` for `Home`, `Favorite`, and `Menu` composables.
    - Added default transitions to the main `NavHost` in `AppNavHost.kt`.

- **Placeholder Screens:**
    - Added simple `Text` composables as placeholders for `FavoriteScreen` and `MenuScreen` in `MainNavGraph.kt`.

- **Navigation Logic:**
    - Updated `AppBottomNavBar.kt`: When a bottom navigation item is clicked, it now navigates with `launchSingleTop = true` and pops up to `MainScreen.Home` to ensure a consistent navigation stack.
    - In `MainNavGraph.kt`, when navigating up from `DrawScreen`, it now uses `navController.navigateUp()` instead of a specific route.

- **Minor:**
    - Updated deployment target in `.idea/deploymentTargetSelector.xml`.