### PR TITLE
Refactored `HomeScreen` with `SharedTransition` and `HomeScreenItemDetails`.

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -4,7 +4,7 @@
     <selectionStates>
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
-        <DropdownSelection timestamp="2025-09-21T15:17:19.396497Z">
+        <DropdownSelection timestamp="2025-09-21T20:06:19.832248Z">
           <Target type="DEFAULT_BOOT">
             <handle>
               <DeviceId pluginId="PhysicalDevice" identifier="serial=R5CX22P8R0T" />

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -20,11 +20,13 @@
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
+        android:hardwareAccelerated="true"
         android:supportsRtl="true"
         android:theme="@style/Theme.MagicMessage">
 
         <activity
             android:name=".presentation.MainActivity"
+            android:hardwareAccelerated="true"
             android:exported="true"
             android:theme="@style/Theme.MagicMessage">
 

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/core/ui/components/list/ListItemOption.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/core/ui/components/list/ListItemOption.kt
@@ -42,12 +42,15 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.dp
 import com.stoyanvuchev.magicmessage.core.ui.components.interaction.rememberRipple
+import com.stoyanvuchev.magicmessage.core.ui.effect.defaultHazeEffect
 import com.stoyanvuchev.magicmessage.core.ui.theme.Theme
+import dev.chrisbanes.haze.HazeState
 
 @Composable
 fun ListItemOption(
     modifier: Modifier = Modifier,
     onClick: () -> Unit,
+    hazeState: HazeState,
     label: @Composable () -> Unit,
     icon: @Composable (() -> Unit)? = null
 ) {
@@ -66,7 +69,8 @@ fun ListItemOption(
                     indication = rememberRipple(),
                     onClick = onClick
                 )
-                .background(color = Theme.colors.surfaceElevationHigh)
+                .defaultHazeEffect(hazeState = hazeState)
+                .background(Theme.colors.surfaceElevationHigh.copy(.5f))
                 .border(
                     width = 1.dp,
                     color = Theme.colors.outline,

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/core/ui/effect/DefaultHazeEffect.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/core/ui/effect/DefaultHazeEffect.kt
@@ -42,7 +42,7 @@ fun Modifier.defaultHazeEffect(
             style = HazeStyle(
                 tint = HazeTint(color = Theme.colors.surfaceElevationLow.copy(.75f)),
                 blurRadius = 16.dp,
-                noiseFactor = -.5f,
+                noiseFactor = -1f,
                 backgroundColor = Theme.colors.surfaceElevationLow
 
             )

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/AppNavHost.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/AppNavHost.kt
@@ -26,24 +26,19 @@ package com.stoyanvuchev.magicmessage.presentation
 
 import android.annotation.SuppressLint
 import android.net.Uri
-import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.ExperimentalSharedTransitionApi
-import androidx.compose.animation.SharedTransitionLayout
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
-import com.stoyanvuchev.magicmessage.core.ui.animation.LocalAnimatedContentScope
 import com.stoyanvuchev.magicmessage.core.ui.navigation.InitialScreen
 import com.stoyanvuchev.magicmessage.core.ui.theme.Theme
 import com.stoyanvuchev.magicmessage.core.ui.transition.DefaultNavigationTransitions
-import com.stoyanvuchev.magicmessage.core.ui.transition.LocalSharedTransitionScope
 import com.stoyanvuchev.magicmessage.framework.export.ExporterState
 import com.stoyanvuchev.magicmessage.presentation.boarding.BoardingScreen
 import com.stoyanvuchev.magicmessage.presentation.boarding.boardingNavGraph
@@ -65,66 +60,55 @@ fun AppNavHost(
     exporterProgress: Int,
     exportedUri: Uri?,
     onDismissExportDialog: () -> Unit
-) = SharedTransitionLayout {
+) {
 
     val hazeState = rememberHazeState()
 
-    AnimatedContent(
-        targetState = Unit,
-        label = "Top level AnimatedContent"
-    ) { targetState ->
+    Scaffold(
+        modifier = Modifier.fillMaxSize(),
+        containerColor = Theme.colors.surfaceElevationLow,
+        contentColor = Theme.colors.onSurfaceElevationLow,
+        bottomBar = {
 
-        CompositionLocalProvider(
-            LocalSharedTransitionScope provides this@SharedTransitionLayout,
-            LocalAnimatedContentScope provides this@AnimatedContent
+            AppBottomNavBar(
+                navController = navController,
+                hazeState = hazeState
+            )
+
+        }
+    ) { _ ->
+
+        NavHost(
+            modifier = Modifier
+                .fillMaxSize()
+                .hazeSource(
+                    state = hazeState,
+                    key = "root_haze_source"
+                ),
+            enterTransition = remember { { DefaultNavigationTransitions.enter(this) } },
+            exitTransition = remember { { DefaultNavigationTransitions.exit(this) } },
+            popEnterTransition = remember { { DefaultNavigationTransitions.popEnter(this) } },
+            popExitTransition = remember { { DefaultNavigationTransitions.popExit(this) } },
+            navController = navController,
+            startDestination = InitialScreen
         ) {
 
-            Scaffold(
-                modifier = Modifier.fillMaxSize(),
-                containerColor = Theme.colors.surfaceElevationLow,
-                contentColor = Theme.colors.onSurfaceElevationLow,
-                bottomBar = {
-
-                    AppBottomNavBar(
-                        navController = navController,
-                        hazeState = hazeState
-                    )
-
-                }
-            ) { _ ->
-
-                NavHost(
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .hazeSource(state = hazeState),
-                    enterTransition = remember { { DefaultNavigationTransitions.enter(this) } },
-                    exitTransition = remember { { DefaultNavigationTransitions.exit(this) } },
-                    popEnterTransition = remember { { DefaultNavigationTransitions.popEnter(this) } },
-                    popExitTransition = remember { { DefaultNavigationTransitions.popExit(this) } },
-                    navController = navController,
-                    startDestination = InitialScreen
-                ) {
-
-                    composable<InitialScreen> {
-                        LaunchedEffect(isBoardingComplete) {
-                            if (isBoardingComplete != null) {
-                                navController.navigate(
-                                    if (isBoardingComplete) MainScreen.Home
-                                    else BoardingScreen.GetStarted
-                                ) {
-                                    popUpTo(navController.graph.id) { inclusive = false }
-                                    launchSingleTop = true
-                                }
-                            }
+            composable<InitialScreen> {
+                LaunchedEffect(isBoardingComplete) {
+                    if (isBoardingComplete != null) {
+                        navController.navigate(
+                            if (isBoardingComplete) MainScreen.Home
+                            else BoardingScreen.GetStarted
+                        ) {
+                            popUpTo(navController.graph.id) { inclusive = false }
+                            launchSingleTop = true
                         }
                     }
-
-                    boardingNavGraph(navController = navController)
-                    mainNavGraph(navController = navController)
-
                 }
-
             }
+
+            boardingNavGraph(navController = navController)
+            mainNavGraph(navController = navController)
 
         }
 

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/main/home_screen/HomeScreen.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/main/home_screen/HomeScreen.kt
@@ -25,14 +25,11 @@
 package com.stoyanvuchev.magicmessage.presentation.main.home_screen
 
 import androidx.activity.compose.BackHandler
-import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.ExperimentalSharedTransitionApi
-import androidx.compose.animation.animateContentSize
+import androidx.compose.animation.SharedTransitionLayout
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
-import androidx.compose.animation.togetherWith
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -53,30 +50,28 @@ import androidx.compose.foundation.lazy.grid.itemsIndexed
 import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.material3.FabPosition
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import com.stoyanvuchev.magicmessage.R
 import com.stoyanvuchev.magicmessage.core.ui.components.AuraButton
 import com.stoyanvuchev.magicmessage.core.ui.components.bottom_nav_bar.BottomNavBarTokens.NavigationBarHeight
-import com.stoyanvuchev.magicmessage.core.ui.components.list.ListItemOption
 import com.stoyanvuchev.magicmessage.core.ui.components.top_bar.TopBar
 import com.stoyanvuchev.magicmessage.core.ui.effect.defaultHazeEffect
 import com.stoyanvuchev.magicmessage.core.ui.event.NavigationEvent
 import com.stoyanvuchev.magicmessage.core.ui.theme.Theme
-import com.stoyanvuchev.magicmessage.core.ui.transition.LocalSharedTransitionScope
 import com.stoyanvuchev.magicmessage.core.ui.transition.defaultBoundsTransformation
 import com.stoyanvuchev.magicmessage.domain.model.CreationModel
 import com.stoyanvuchev.magicmessage.presentation.main.MainScreen
@@ -91,370 +86,263 @@ fun HomeScreen(
     onNavigationEvent: (NavigationEvent) -> Unit
 ) {
 
-    with(LocalSharedTransitionScope.current ?: return) {
+    val lazyGridState = rememberLazyGridState()
+    val hazeState = rememberHazeState()
+    var sharedCreation by remember { mutableStateOf<CreationModel?>(null) }
+    val boundsTransform = remember { defaultBoundsTransformation }
+    val aspectRatio = remember { 3f / 4f }
 
-        val lazyGridState = rememberLazyGridState()
-        val hazeState = rememberHazeState()
-        var isDetailsShown by remember { mutableStateOf(false) }
-        var sharedKey by remember { mutableLongStateOf(0L) }
-        var sharedCreation by remember { mutableStateOf<CreationModel?>(null) }
-        val boundsTransform = remember { defaultBoundsTransformation }
+    BackHandler(enabled = sharedCreation != null) { sharedCreation = null }
 
-        BackHandler(enabled = isDetailsShown) { isDetailsShown = false }
+    Scaffold(
+        modifier = Modifier.fillMaxSize(),
+        containerColor = Theme.colors.surfaceElevationLow,
+        contentColor = Theme.colors.onSurfaceElevationLow,
+        topBar = {
 
-        AnimatedContent(
-            modifier = Modifier.fillMaxSize(),
-            targetState = isDetailsShown,
-            transitionSpec = { fadeIn() togetherWith fadeOut() }
-        ) { target ->
+            TopBar(
+                modifier = Modifier.defaultHazeEffect(hazeState = hazeState),
+                title = { Text(text = stringResource(R.string.home_screen_label)) }
+            )
 
-            if (!target) {
+        },
+        floatingActionButtonPosition = FabPosition.Center,
+        floatingActionButton = {
 
-                Scaffold(
-                    modifier = Modifier.fillMaxSize(),
-                    containerColor = Theme.colors.surfaceElevationLow,
-                    contentColor = Theme.colors.onSurfaceElevationLow,
-                    topBar = {
+            if (sharedCreation == null) {
 
-                        TopBar(
-                            modifier = Modifier.defaultHazeEffect(hazeState = hazeState),
-                            title = { Text(text = stringResource(R.string.home_screen_label)) }
-                        )
-
+                AuraButton(
+                    onClick = remember {
+                        {
+                            onNavigationEvent(
+                                NavigationEvent.NavigateTo(
+                                    MainScreen.Draw(null)
+                                )
+                            )
+                        }
                     },
-                    floatingActionButtonPosition = FabPosition.Center,
-                    floatingActionButton = {
-
-                        AuraButton(
-                            onClick = remember {
-                                {
-                                    onNavigationEvent(
-                                        NavigationEvent.NavigateTo(
-                                            MainScreen.Draw(null)
-                                        )
-                                    )
-                                }
-                            },
-                            hazeState = hazeState,
-                            isGlowVisible = true,
-                            size = 56.dp
-                        ) {
-
-                            Icon(
-                                modifier = Modifier.size(24.dp),
-                                painter = painterResource(R.drawable.pencil_icon),
-                                contentDescription = null
-                            )
-
-                        }
-
-                    },
-                    bottomBar = {
-
-                        Spacer(
-                            modifier = Modifier
-                                .navigationBarsPadding()
-                                .height(NavigationBarHeight)
-                        )
-
-                    }
-                ) { innerPadding ->
-
-                    LazyVerticalGrid(
-                        modifier = Modifier
-                            .fillMaxSize()
-                            .hazeSource(state = hazeState),
-                        contentPadding = innerPadding,
-                        state = lazyGridState,
-                        columns = GridCells.Fixed(2),
-                        horizontalArrangement = Arrangement.spacedBy(12.dp),
-                        verticalArrangement = Arrangement.spacedBy(12.dp)
-                    ) {
-
-                        if (state.exportedCreationsList.isNotEmpty()) {
-
-                            item(
-                                span = { GridItemSpan(this.maxLineSpan) }
-                            ) {
-
-                                Spacer(modifier = Modifier.height(12.dp))
-
-                                Text(
-                                    modifier = Modifier
-                                        .padding(horizontal = 24.dp)
-                                        .padding(top = 24.dp),
-                                    text = stringResource(R.string.home_screen_exported_label),
-                                    style = Theme.typefaces.bodySmall,
-                                    color = Theme.colors.onSurfaceElevationLow.copy(.5f)
-                                )
-
-                                Spacer(modifier = Modifier.height(0.dp))
-
-                            }
-
-                            itemsIndexed(
-                                items = state.exportedCreationsList,
-                                key = { _, creation -> "exported_item_${creation.createdAt}" }
-                            ) { i, creation ->
-
-                                val startPadding by remember(i) {
-                                    derivedStateOf { if (i % 2 == 0) 24.dp else 0.dp }
-                                }
-
-                                val endPadding by remember(i) {
-                                    derivedStateOf { if (i % 2 == 0) 0.dp else 24.dp }
-                                }
-
-                                HomeScreenCreationItem(
-                                    modifier = Modifier
-                                        .padding(
-                                            start = startPadding,
-                                            end = endPadding
-                                        )
-                                        .fillMaxWidth()
-                                        .aspectRatio(3f / 4f)
-                                        .sharedElement(
-                                            sharedContentState = rememberSharedContentState(
-                                                key = creation.id ?: 0
-                                            ),
-                                            animatedVisibilityScope = this@AnimatedContent,
-                                            boundsTransform = boundsTransform,
-                                        )
-                                        .animateItem(),
-                                    creation = creation,
-                                    onNavigationEvent = onNavigationEvent,
-                                    onLongClick = remember {
-                                        {
-                                            sharedCreation = creation
-                                            sharedKey = creation.id ?: 0
-                                            isDetailsShown = true
-                                        }
-                                    }
-                                )
-
-                            }
-
-                        }
-
-                        if (state.draftedCreationsList.isNotEmpty()) {
-
-                            item(
-                                span = { GridItemSpan(this.maxLineSpan) }
-                            ) {
-
-                                Spacer(modifier = Modifier.height(12.dp))
-
-                                Text(
-                                    modifier = Modifier
-                                        .padding(horizontal = 24.dp)
-                                        .padding(top = 24.dp)
-                                        .animateItem(),
-                                    text = stringResource(R.string.home_screen_drafted_label),
-                                    style = Theme.typefaces.bodySmall,
-                                    color = Theme.colors.onSurfaceElevationLow.copy(.5f)
-                                )
-
-                                Spacer(modifier = Modifier.height(0.dp))
-
-                            }
-
-                            itemsIndexed(
-                                items = state.draftedCreationsList,
-                                key = { _, creation -> "drafted_item_${creation.createdAt}" }
-                            ) { i, creation ->
-
-                                val startPadding by remember(i) {
-                                    derivedStateOf { if (i % 2 == 0) 24.dp else 0.dp }
-                                }
-
-                                val endPadding by remember(i) {
-                                    derivedStateOf { if (i % 2 == 0) 0.dp else 24.dp }
-                                }
-
-                                HomeScreenCreationItem(
-                                    modifier = Modifier
-                                        .padding(
-                                            start = startPadding,
-                                            end = endPadding
-                                        )
-                                        .fillMaxWidth()
-                                        .aspectRatio(3f / 4f)
-                                        .sharedElement(
-                                            sharedContentState = rememberSharedContentState(
-                                                key = creation.id ?: 0
-                                            ),
-                                            animatedVisibilityScope = this@AnimatedContent,
-                                            boundsTransform = boundsTransform,
-                                        )
-                                        .animateItem(),
-                                    creation = creation,
-                                    onNavigationEvent = onNavigationEvent,
-                                    onLongClick = remember {
-                                        {
-                                            sharedCreation = creation
-                                            sharedKey = creation.id ?: 0
-                                            isDetailsShown = true
-                                        }
-                                    }
-                                )
-
-                            }
-
-                        }
-
-                        item(
-                            span = { GridItemSpan(this.maxLineSpan) }
-                        ) {
-                            Spacer(modifier = Modifier.height(164.dp))
-                        }
-
-                    }
-
-                }
-
-            } else {
-
-                Scaffold(
-                    modifier = Modifier.fillMaxSize(),
-                    containerColor = Theme.colors.surfaceElevationLow,
-                    contentColor = Theme.colors.onSurfaceElevationLow,
-                    topBar = {
-
-                        TopBar(
-                            title = remember { {} },
-                            navigationAction = {
-
-                                IconButton(
-                                    onClick = remember { { isDetailsShown = false } }
-                                ) {
-
-                                    Icon(
-                                        modifier = Modifier.size(28.dp),
-                                        painter = painterResource(R.drawable.arrow_left_outlined),
-                                        contentDescription = null
-                                    )
-
-                                }
-
-                            }
-                        )
-
-                    }
-                ) { innerPadding ->
-
-                    Column(
-                        modifier = Modifier
-                            .fillMaxSize()
-                            .padding(innerPadding)
-                            .padding(bottom = NavigationBarHeight)
-                            .clickable(
-                                onClick = remember { { isDetailsShown = false } },
-                                indication = null,
-                                interactionSource = remember { MutableInteractionSource() }
-                            ),
-                        horizontalAlignment = Alignment.CenterHorizontally,
-                        verticalArrangement = Arrangement.Center
-                    ) {
-
-                        sharedCreation?.let {
-
-                            HomeScreenCreationItem(
-                                modifier = Modifier
-                                    .padding(horizontal = 64.dp)
-                                    .fillMaxWidth()
-                                    .aspectRatio(3f / 4f)
-                                    .sharedElement(
-                                        sharedContentState = rememberSharedContentState(key = sharedKey),
-                                        animatedVisibilityScope = this@AnimatedContent,
-                                        boundsTransform = boundsTransform,
-                                    ),
-                                creation = it,
-                                onNavigationEvent = onNavigationEvent,
-                                onLongClick = remember { {} }
-                            )
-
-                            Spacer(modifier = Modifier.height(64.dp))
-
-                            if (it.isDraft) {
-
-                                ListItemOption(
-                                    modifier = Modifier.padding(horizontal = 32.dp),
-                                    onClick = remember {
-                                        {
-                                            onUIAction(HomeScreenUIAction.ExportGif(it))
-                                            isDetailsShown = false
-                                        }
-                                    },
-                                    label = { Text(text = "Export GIF") },
-                                    icon = {
-
-                                        Icon(
-                                            modifier = Modifier.size(24.dp),
-                                            painter = painterResource(R.drawable.export),
-                                            contentDescription = null
-                                        )
-
-                                    }
-                                )
-
-                                Spacer(modifier = Modifier.height(8.dp))
-
-                            }
-
-                            var isFavorite by remember { mutableStateOf(it.isFavorite) }
-
-                            ListItemOption(
-                                modifier = Modifier.padding(horizontal = 32.dp),
-                                onClick = remember { { isFavorite = !isFavorite } },
-                                label = {
-
-                                    Text(
-                                        modifier = Modifier.animateContentSize(
-                                            alignment = Alignment.Center
-                                        ),
-                                        text = if (isFavorite) "Remove from Favorite"
-                                        else "Add to Favorite"
-                                    )
-
-                                },
-                                icon = {
-
-                                    Icon(
-                                        modifier = Modifier.size(24.dp),
-                                        painter = painterResource(
-                                            if (isFavorite) R.drawable.favorite_filled
-                                            else R.drawable.favorite_outlined
-                                        ),
-                                        contentDescription = null
-                                    )
-
-                                }
-                            )
-
-                            Spacer(modifier = Modifier.height(8.dp))
-
-                            ListItemOption(
-                                modifier = Modifier.padding(horizontal = 32.dp),
-                                onClick = remember { {} },
-                                label = { Text(text = "Move to Trash") },
-                                icon = {
-
-                                    Icon(
-                                        modifier = Modifier.size(24.dp),
-                                        painter = painterResource(R.drawable.delete),
-                                        contentDescription = null
-                                    )
-
-                                }
-                            )
-
-                        }
-
-                    }
+                    hazeState = hazeState,
+                    isGlowVisible = true,
+                    size = 56.dp
+                ) {
+
+                    Icon(
+                        modifier = Modifier.size(24.dp),
+                        painter = painterResource(R.drawable.pencil_icon),
+                        contentDescription = null
+                    )
 
                 }
 
             }
+
+        },
+        bottomBar = {
+
+            Spacer(
+                modifier = Modifier
+                    .navigationBarsPadding()
+                    .height(NavigationBarHeight)
+            )
+
+        }
+    ) { innerPadding ->
+
+        SharedTransitionLayout {
+
+            var canvasSize by remember { mutableStateOf(IntSize.Zero) }
+
+            LazyVerticalGrid(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .hazeSource(
+                        state = hazeState,
+                        key = "home_items_source"
+                    ),
+                contentPadding = innerPadding,
+                state = lazyGridState,
+                columns = GridCells.Fixed(2),
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+                verticalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+
+                if (state.exportedCreationsList.isNotEmpty()) {
+
+                    item(
+                        span = { GridItemSpan(this.maxLineSpan) }
+                    ) {
+
+                        Spacer(modifier = Modifier.height(12.dp))
+
+                        Text(
+                            modifier = Modifier
+                                .padding(horizontal = 24.dp)
+                                .padding(top = 24.dp),
+                            text = stringResource(R.string.home_screen_exported_label),
+                            style = Theme.typefaces.bodySmall,
+                            color = Theme.colors.onSurfaceElevationLow.copy(.5f)
+                        )
+
+                        Spacer(modifier = Modifier.height(0.dp))
+
+                    }
+
+                    itemsIndexed(
+                        items = state.exportedCreationsList,
+                        key = { _, creation -> "exported_item_${creation.createdAt}" }
+                    ) { i, creation ->
+
+                        val startPadding by remember(i) {
+                            derivedStateOf { if (i % 2 == 0) 24.dp else 0.dp }
+                        }
+
+                        val endPadding by remember(i) {
+                            derivedStateOf { if (i % 2 == 0) 0.dp else 24.dp }
+                        }
+
+                        val visible by rememberUpdatedState(
+                            sharedCreation?.id != creation.id
+                        )
+
+                        AnimatedVisibility(
+                            modifier = Modifier
+                                .animateItem()
+                                .padding(
+                                    start = startPadding,
+                                    end = endPadding
+                                )
+                                .fillMaxWidth()
+                                .aspectRatio(aspectRatio),
+                            visible = visible,
+                            enter = fadeIn(),
+                            exit = fadeOut()
+                        ) {
+
+                            HomeScreenCreationItem(
+                                modifier = Modifier
+                                    .fillMaxSize()
+                                    .sharedElement(
+                                        sharedContentState = rememberSharedContentState(
+                                            key = creation.id ?: 0
+                                        ),
+                                        animatedVisibilityScope = this@AnimatedVisibility,
+                                        boundsTransform = boundsTransform,
+                                    ),
+                                creation = creation,
+                                onNavigationEvent = onNavigationEvent,
+                                onLongClick = remember {
+                                    {
+                                        if (canvasSize == IntSize.Zero) canvasSize = it
+                                        sharedCreation = creation
+                                    }
+                                }
+                            )
+
+                        }
+
+                    }
+
+                }
+
+                if (state.draftedCreationsList.isNotEmpty()) {
+
+                    item(
+                        span = { GridItemSpan(this.maxLineSpan) }
+                    ) {
+
+                        Spacer(modifier = Modifier.height(12.dp))
+
+                        Text(
+                            modifier = Modifier
+                                .padding(horizontal = 24.dp)
+                                .padding(top = 24.dp)
+                                .animateItem(),
+                            text = stringResource(R.string.home_screen_drafted_label),
+                            style = Theme.typefaces.bodySmall,
+                            color = Theme.colors.onSurfaceElevationLow.copy(.5f)
+                        )
+
+                        Spacer(modifier = Modifier.height(0.dp))
+
+                    }
+
+                    itemsIndexed(
+                        items = state.draftedCreationsList,
+                        key = { _, creation -> "drafted_item_${creation.createdAt}" }
+                    ) { i, creation ->
+
+                        val startPadding by remember(i) {
+                            derivedStateOf { if (i % 2 == 0) 24.dp else 0.dp }
+                        }
+
+                        val endPadding by remember(i) {
+                            derivedStateOf { if (i % 2 == 0) 0.dp else 24.dp }
+                        }
+
+                        val visible by rememberUpdatedState(
+                            sharedCreation?.id != creation.id
+                        )
+
+                        AnimatedVisibility(
+                            modifier = Modifier
+                                .animateItem()
+                                .padding(
+                                    start = startPadding,
+                                    end = endPadding
+                                )
+                                .fillMaxWidth()
+                                .aspectRatio(aspectRatio),
+                            visible = visible,
+                            enter = fadeIn(),
+                            exit = fadeOut()
+                        ) {
+
+                            HomeScreenCreationItem(
+                                modifier = Modifier
+                                    .fillMaxSize()
+                                    .sharedElement(
+                                        sharedContentState = rememberSharedContentState(
+                                            key = creation.id ?: 0
+                                        ),
+                                        animatedVisibilityScope = this@AnimatedVisibility,
+                                        boundsTransform = boundsTransform,
+                                    ),
+                                creation = creation,
+                                onNavigationEvent = onNavigationEvent,
+                                onLongClick = remember {
+                                    {
+                                        if (canvasSize == IntSize.Zero) canvasSize = it
+                                        sharedCreation = creation
+                                    }
+                                }
+                            )
+
+                        }
+                    }
+
+                }
+
+                item(
+                    span = { GridItemSpan(this.maxLineSpan) }
+                ) {
+                    Spacer(modifier = Modifier.height(164.dp))
+                }
+
+            }
+
+            HomeScreenItemDetails(
+                modifier = Modifier
+                    .padding(bottom = NavigationBarHeight)
+                    .fillMaxSize(),
+                innerPadding = innerPadding,
+                hazeState = hazeState,
+                boundsTransform = boundsTransform,
+                creation = sharedCreation,
+                canvasSize = canvasSize,
+                onDismiss = remember { { sharedCreation = null } },
+                onUIAction = onUIAction,
+                onNavigationEvent = onNavigationEvent
+            )
 
         }
 

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/main/home_screen/HomeScreenCreationItem.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/main/home_screen/HomeScreenCreationItem.kt
@@ -26,17 +26,25 @@ package com.stoyanvuchev.magicmessage.presentation.main.home_screen
 
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.drawscope.scale
+import androidx.compose.ui.layout.onPlaced
 import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.dp
 import com.stoyanvuchev.magicmessage.core.ui.components.interaction.rememberRipple
 import com.stoyanvuchev.magicmessage.core.ui.event.NavigationEvent
 import com.stoyanvuchev.magicmessage.core.ui.ext.drawStroke
@@ -50,13 +58,34 @@ fun HomeScreenCreationItem(
     modifier: Modifier = Modifier,
     creation: CreationModel,
     onNavigationEvent: (NavigationEvent) -> Unit,
-    onLongClick: () -> Unit
+    onLongClick: (IntSize) -> Unit
 ) {
+
+    var canvasSize by remember { mutableStateOf(IntSize.Zero) }
+
+    val scaleX by remember {
+        derivedStateOf {
+            findScaleFromSize(
+                a = creation.drawConfiguration.canvasWidth.toFloat(),
+                b = canvasSize.width.toFloat()
+            )
+        }
+    }
+
+    val scaleY by remember {
+        derivedStateOf {
+            findScaleFromSize(
+                a = creation.drawConfiguration.canvasHeight.toFloat(),
+                b = canvasSize.height.toFloat()
+            )
+        }
+    }
 
     Canvas(
         modifier = modifier
+            .onPlaced { canvasSize = it.size }
             .combinedClickable(
-                onClick = remember(creation.id) {
+                onClick = remember {
                     {
                         onNavigationEvent(
                             NavigationEvent.NavigateTo(
@@ -65,24 +94,19 @@ fun HomeScreenCreationItem(
                         )
                     }
                 },
-                onLongClick = onLongClick,
+                onLongClick = remember { { onLongClick(canvasSize) } },
                 interactionSource = remember { MutableInteractionSource() },
                 indication = rememberRipple(),
                 role = Role.Image
             )
             .clip(shape = Theme.shapes.smallShape)
             .background(color = Theme.colors.surfaceElevationHigh)
+            .border(
+                width = 1.dp,
+                color = Theme.colors.outline,
+                shape = Theme.shapes.smallShape
+            )
     ) {
-
-        val scaleX = findScaleFromSize(
-            a = creation.drawConfiguration.canvasWidth.toFloat(),
-            b = this.size.width
-        )
-
-        val scaleY = findScaleFromSize(
-            a = creation.drawConfiguration.canvasHeight.toFloat(),
-            b = this.size.height
-        )
 
         // Draw the background layer.
         when (creation.drawConfiguration.bgLayer) {

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/main/home_screen/HomeScreenItemDetails.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/main/home_screen/HomeScreenItemDetails.kt
@@ -1,0 +1,217 @@
+package com.stoyanvuchev.magicmessage.presentation.main.home_screen
+
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.ExperimentalSharedTransitionApi
+import androidx.compose.animation.SharedTransitionScope
+import androidx.compose.animation.animateContentSize
+import androidx.compose.animation.core.SpringSpec
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.togetherWith
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.dp
+import com.stoyanvuchev.magicmessage.R
+import com.stoyanvuchev.magicmessage.core.ui.components.bottom_nav_bar.BottomNavBarTokens.NavigationBarHeight
+import com.stoyanvuchev.magicmessage.core.ui.components.list.ListItemOption
+import com.stoyanvuchev.magicmessage.core.ui.effect.defaultHazeEffect
+import com.stoyanvuchev.magicmessage.core.ui.event.NavigationEvent
+import com.stoyanvuchev.magicmessage.domain.model.CreationModel
+import dev.chrisbanes.haze.HazeState
+
+@OptIn(ExperimentalSharedTransitionApi::class)
+@Composable
+fun SharedTransitionScope.HomeScreenItemDetails(
+    modifier: Modifier = Modifier,
+    creation: CreationModel?,
+    innerPadding: PaddingValues,
+    hazeState: HazeState,
+    boundsTransform: (Rect, Rect) -> SpringSpec<Rect>,
+    canvasSize: IntSize,
+    onDismiss: () -> Unit,
+    onUIAction: (HomeScreenUIAction) -> Unit,
+    onNavigationEvent: (NavigationEvent) -> Unit
+) {
+
+    val isBackgroundVisible by rememberUpdatedState(creation != null)
+
+    AnimatedVisibility(
+        modifier = Modifier.fillMaxSize(),
+        visible = isBackgroundVisible,
+        enter = fadeIn(),
+        exit = fadeOut()
+    ) {
+
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .navigationBarsPadding()
+                .padding(bottom = NavigationBarHeight)
+                .defaultHazeEffect(hazeState = hazeState)
+                .padding(top = innerPadding.calculateTopPadding())
+        )
+
+    }
+
+    AnimatedContent(
+        modifier = modifier,
+        targetState = creation,
+        transitionSpec = remember { { fadeIn() togetherWith fadeOut() } },
+        label = "HomeScreenItemDetails"
+    ) { sharedCreation ->
+
+        if (sharedCreation != null) {
+
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .navigationBarsPadding()
+                    .padding(top = innerPadding.calculateTopPadding())
+                    .clickable(
+                        onClick = onDismiss,
+                        indication = null,
+                        interactionSource = remember { MutableInteractionSource() }
+                    ),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.Center
+            ) {
+
+                val density = LocalDensity.current
+                val dpSize by remember {
+                    derivedStateOf {
+                        with(density) {
+                            DpSize(
+                                width = canvasSize.width.toDp(),
+                                height = canvasSize.height.toDp()
+                            )
+                        }
+                    }
+                }
+
+                HomeScreenCreationItem(
+                    modifier = Modifier
+                        .size(dpSize)
+                        .sharedElement(
+                            sharedContentState = rememberSharedContentState(
+                                key = sharedCreation.id ?: 0
+                            ),
+                            animatedVisibilityScope = this@AnimatedContent,
+                            boundsTransform = boundsTransform,
+                        ),
+                    creation = sharedCreation,
+                    onNavigationEvent = onNavigationEvent,
+                    onLongClick = remember { {} }
+                )
+
+                Spacer(modifier = Modifier.height(64.dp))
+
+                if (sharedCreation.isDraft) {
+
+                    ListItemOption(
+                        modifier = Modifier.padding(horizontal = 32.dp),
+                        onClick = remember {
+                            {
+                                onUIAction(HomeScreenUIAction.ExportGif(sharedCreation))
+                                onDismiss()
+                            }
+                        },
+                        hazeState = hazeState,
+                        label = { Text(text = "Export GIF") },
+                        icon = {
+
+                            Icon(
+                                modifier = Modifier.size(24.dp),
+                                painter = painterResource(R.drawable.export),
+                                contentDescription = null
+                            )
+
+                        }
+                    )
+
+                    Spacer(modifier = Modifier.height(8.dp))
+
+                }
+
+                var isFavorite by remember { mutableStateOf(sharedCreation.isFavorite) }
+
+                ListItemOption(
+                    modifier = Modifier.padding(horizontal = 32.dp),
+                    onClick = remember { { isFavorite = !isFavorite } },
+                    hazeState = hazeState,
+                    label = {
+
+                        Text(
+                            modifier = Modifier.animateContentSize(
+                                alignment = Alignment.Center
+                            ),
+                            text = if (isFavorite) "Remove from Favorite"
+                            else "Add to Favorite"
+                        )
+
+                    },
+                    icon = {
+
+                        Icon(
+                            modifier = Modifier.size(24.dp),
+                            painter = painterResource(
+                                if (isFavorite) R.drawable.favorite_filled
+                                else R.drawable.favorite_outlined
+                            ),
+                            contentDescription = null
+                        )
+
+                    }
+                )
+
+                Spacer(modifier = Modifier.height(8.dp))
+
+                ListItemOption(
+                    modifier = Modifier.padding(horizontal = 32.dp),
+                    onClick = remember { {} },
+                    hazeState = hazeState,
+                    label = { Text(text = "Move to Trash") },
+                    icon = {
+
+                        Icon(
+                            modifier = Modifier.size(24.dp),
+                            painter = painterResource(R.drawable.delete),
+                            contentDescription = null
+                        )
+
+                    }
+                )
+
+            }
+
+        }
+
+    }
+
+}


### PR DESCRIPTION
This commit introduces a major refactor to the `HomeScreen` to implement shared element transitions for item details and extracts the details view into a new `HomeScreenItemDetails` composable.

**Key Changes:**

- **`HomeScreen` Refactor:**
    - Replaced `AnimatedContent` with `SharedTransitionLayout` and `AnimatedVisibility` for managing the display of creation items and their details.
    - When a creation item is long-clicked, it transitions to the `HomeScreenItemDetails` view.
    - The `AuraButton` (FAB) is now hidden when `sharedCreation` (the selected item for details) is not null.
    - `LazyVerticalGrid`'s `hazeSource` now has a specific key "home_items_source".
    - Removed `isDetailsShown` and `sharedKey` state variables, using `sharedCreation` to manage the details view visibility.
    - Item padding in the grid is maintained.

- **`HomeScreenItemDetails.kt` (New File):**
    - Created a new composable `HomeScreenItemDetails` to display the details of a selected creation.
    - It uses `SharedTransitionScope` to enable shared element transitions from the `HomeScreen` grid.
    - Displays the selected `HomeScreenCreationItem` with appropriate padding and shared element modifiers.
    - Includes options like "Export GIF", "Add/Remove from Favorite", and "Move to Trash" using `ListItemOption`.
    - The background of the details view has a haze effect.
    - Handles dismissal when clicking outside the item details or via the back button.
    - `ListItemOption`s within this view also have a haze effect.

- **`HomeScreenCreationItem.kt`:**
    - Modified `onLongClick` to pass the `IntSize` of the canvas to the callback.
    - The `Canvas` now uses `onPlaced` to get its size.
    - Added a 1.dp border with `Theme.colors.outline` and `Theme.shapes.smallShape`.

- **`DefaultHazeEffect.kt`:**
    - Changed `noiseFactor` from `-0.5f` to `-1f`.

- **`AppNavHost.kt`:**
    - Removed the top-level `SharedTransitionLayout` and `AnimatedContent` as shared transitions are now handled within `HomeScreen`.
    - Removed `CompositionLocalProvider` for `LocalSharedTransitionScope` and `LocalAnimatedContentScope`.
    - `NavHost`'s `hazeSource` key is now "root_haze_source".

- **`ListItemOption.kt`:**
    - Added an optional `hazeState: HazeState` parameter.
    - If `hazeState` is provided, `defaultHazeEffect` is applied to the background.
    - The background color is now `Theme.colors.surfaceElevationHigh.copy(.5f)`.

- **`AndroidManifest.xml`:**
    - Enabled `android:hardwareAccelerated="true"` for both the application and `MainActivity`.