### PR TITLE
Refactored UI components and added Favorite screen.

### DIFF
--- a/app/src/main/java/com/stoyanvuchev/magicmessage/core/ui/DrawingController.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/core/ui/DrawingController.kt
@@ -53,7 +53,8 @@ class DrawingController {
                 totalPointCount = snapshot.totalPointCount
                 drawingEnabled = snapshot.drawingEnabled
                 strokes = mutableStateListOf<StrokeModel>().also { it.addAll(snapshot.strokes) }
-                currentPoints = mutableStateListOf<TimedPoint>().also { it.addAll(snapshot.currentPoints) }
+                currentPoints =
+                    mutableStateListOf<TimedPoint>().also { it.addAll(snapshot.currentPoints) }
                 undoStack = ArrayDeque(snapshot.undoStack)
                 redoStack = ArrayDeque(snapshot.redoStack)
                 startTime = snapshot.startTime
@@ -176,7 +177,6 @@ class DrawingController {
                     brushColor = color
                 )
             )
-            println("AJA: Spawned Particles: ${particlesInternal.size}")
         }
     }
 

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/core/ui/components/AuraButton.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/core/ui/components/AuraButton.kt
@@ -60,6 +60,7 @@ import com.stoyanvuchev.magicmessage.core.ui.components.interaction.rememberRipp
 import com.stoyanvuchev.magicmessage.core.ui.effect.defaultHazeEffect
 import com.stoyanvuchev.magicmessage.core.ui.effect.innerAuraGlow
 import com.stoyanvuchev.magicmessage.core.ui.effect.outerAuraGlow
+import com.stoyanvuchev.magicmessage.core.ui.ext.LocalHazeState
 import com.stoyanvuchev.magicmessage.core.ui.theme.Theme
 import dev.chrisbanes.haze.HazeState
 
@@ -67,7 +68,7 @@ import dev.chrisbanes.haze.HazeState
 fun AuraButton(
     modifier: Modifier = Modifier,
     onClick: () -> Unit,
-    hazeState: HazeState,
+    hazeState: HazeState = LocalHazeState.current,
     isGlowVisible: Boolean = true,
     glowColor: Color = Theme.colors.primary,
     size: Dp = 48.dp,

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/core/ui/components/bottom_bar/BottomBar.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/core/ui/components/bottom_bar/BottomBar.kt
@@ -41,6 +41,7 @@ import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.unit.dp
 import com.stoyanvuchev.magicmessage.core.ui.components.bottom_bar.BottomBarTokens.BottomBarHeight
 import com.stoyanvuchev.magicmessage.core.ui.components.bottom_bar.BottomBarTokens.BottomBarItemHorizontalPadding
+import com.stoyanvuchev.magicmessage.core.ui.effect.defaultHazeEffect
 import com.stoyanvuchev.magicmessage.core.ui.theme.Theme
 
 @Composable
@@ -48,31 +49,28 @@ fun BottomBar(
     modifier: Modifier = Modifier,
     windowInsets: WindowInsets = WindowInsets.navigationBars,
     content: @Composable RowScope.() -> Unit
+) = Column(
+    modifier = Modifier
+        .fillMaxWidth()
+        .defaultHazeEffect()
+        .clipToBounds()
+        .then(modifier)
 ) {
 
-    Column(
+    HorizontalDivider(
+        modifier = Modifier.fillMaxWidth(),
+        color = Theme.colors.outline,
+        thickness = 1.dp
+    )
+
+    Row(
         modifier = Modifier
             .fillMaxWidth()
-            .clipToBounds()
-            .then(modifier)
-    ) {
-
-        HorizontalDivider(
-            modifier = Modifier.fillMaxWidth(),
-            color = Theme.colors.outline,
-            thickness = 1.dp
-        )
-
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .windowInsetsPadding(windowInsets)
-                .defaultMinSize(minHeight = BottomBarHeight),
-            horizontalArrangement = Arrangement.spacedBy(BottomBarItemHorizontalPadding),
-            verticalAlignment = Alignment.CenterVertically,
-            content = content
-        )
-
-    }
+            .windowInsetsPadding(windowInsets)
+            .defaultMinSize(minHeight = BottomBarHeight),
+        horizontalArrangement = Arrangement.spacedBy(BottomBarItemHorizontalPadding),
+        verticalAlignment = Alignment.CenterVertically,
+        content = content
+    )
 
 }

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/core/ui/components/bottom_nav_bar/BottomNavBar.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/core/ui/components/bottom_nav_bar/BottomNavBar.kt
@@ -42,6 +42,7 @@ import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.unit.dp
 import com.stoyanvuchev.magicmessage.core.ui.components.bottom_nav_bar.BottomNavBarTokens.NavigationBarHeight
 import com.stoyanvuchev.magicmessage.core.ui.components.bottom_nav_bar.BottomNavBarTokens.NavigationBarItemHorizontalPadding
+import com.stoyanvuchev.magicmessage.core.ui.effect.defaultHazeEffect
 import com.stoyanvuchev.magicmessage.core.ui.theme.Theme
 
 @Composable
@@ -49,32 +50,29 @@ fun BottomNavBar(
     modifier: Modifier = Modifier,
     windowInsets: WindowInsets = WindowInsets.navigationBars,
     content: @Composable RowScope.() -> Unit
+) = Column(
+    modifier = Modifier
+        .fillMaxWidth()
+        .defaultHazeEffect()
+        .clipToBounds()
+        .then(modifier)
 ) {
 
-    Column(
+    HorizontalDivider(
+        modifier = Modifier.fillMaxWidth(),
+        color = Theme.colors.outline,
+        thickness = 1.dp
+    )
+
+    Row(
         modifier = Modifier
             .fillMaxWidth()
-            .clipToBounds()
-            .then(modifier)
-    ) {
-
-        HorizontalDivider(
-            modifier = Modifier.fillMaxWidth(),
-            color = Theme.colors.outline,
-            thickness = 1.dp
-        )
-
-        Row(
-            modifier = Modifier
-                    .fillMaxWidth()
-                    .windowInsetsPadding(windowInsets)
-                    .defaultMinSize(minHeight = NavigationBarHeight)
-                    .selectableGroup(),
-            horizontalArrangement = Arrangement.spacedBy(NavigationBarItemHorizontalPadding),
-            verticalAlignment = Alignment.CenterVertically,
-            content = content
-        )
-
-    }
+            .windowInsetsPadding(windowInsets)
+            .defaultMinSize(minHeight = NavigationBarHeight)
+            .selectableGroup(),
+        horizontalArrangement = Arrangement.spacedBy(NavigationBarItemHorizontalPadding),
+        verticalAlignment = Alignment.CenterVertically,
+        content = content
+    )
 
 }

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/core/ui/components/grid/GridCreationItem.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/core/ui/components/grid/GridCreationItem.kt
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-package com.stoyanvuchev.magicmessage.presentation.main.home_screen
+package com.stoyanvuchev.magicmessage.core.ui.components.grid
 
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
@@ -38,27 +38,27 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.compositeOver
 import androidx.compose.ui.graphics.drawscope.scale
 import androidx.compose.ui.layout.onPlaced
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import com.stoyanvuchev.magicmessage.core.ui.components.interaction.rememberRipple
-import com.stoyanvuchev.magicmessage.core.ui.event.NavigationEvent
 import com.stoyanvuchev.magicmessage.core.ui.ext.drawStroke
 import com.stoyanvuchev.magicmessage.core.ui.theme.Theme
 import com.stoyanvuchev.magicmessage.domain.layer.BackgroundLayer
 import com.stoyanvuchev.magicmessage.domain.model.CreationModel
-import com.stoyanvuchev.magicmessage.presentation.main.MainScreen
 
 @Composable
-fun HomeScreenCreationItem(
+fun GridCreationItem(
     modifier: Modifier = Modifier,
     creation: CreationModel,
-    onNavigationEvent: (NavigationEvent) -> Unit,
-    onLongClick: (IntSize) -> Unit
+    onCreationClick: (CreationModel) -> Unit,
+    onCreationLongClick: (CreationModel, IntSize) -> Unit
 ) {
 
     var canvasSize by remember { mutableStateOf(IntSize.Zero) }
@@ -84,27 +84,24 @@ fun HomeScreenCreationItem(
     Canvas(
         modifier = modifier
             .onPlaced { canvasSize = it.size }
+            .background(
+                color = Theme.colors.surfaceElevationHigh,
+                shape = Theme.shapes.smallShape
+            )
+            .border(
+                width = 1.dp,
+                color = Theme.colors.outline
+                    .compositeOver(Theme.colors.surfaceElevationLow),
+                shape = Theme.shapes.smallShape
+            )
+            .clip(shape = Theme.shapes.smallShape)
+            .clipToBounds()
             .combinedClickable(
-                onClick = remember {
-                    {
-                        onNavigationEvent(
-                            NavigationEvent.NavigateTo(
-                                MainScreen.Draw(creation.id)
-                            )
-                        )
-                    }
-                },
-                onLongClick = remember { { onLongClick(canvasSize) } },
+                onClick = remember { { onCreationClick(creation) } },
+                onLongClick = remember { { onCreationLongClick(creation, canvasSize) } },
                 interactionSource = remember { MutableInteractionSource() },
                 indication = rememberRipple(),
                 role = Role.Image
-            )
-            .clip(shape = Theme.shapes.smallShape)
-            .background(color = Theme.colors.surfaceElevationHigh)
-            .border(
-                width = 1.dp,
-                color = Theme.colors.outline,
-                shape = Theme.shapes.smallShape
             )
     ) {
 

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/core/ui/components/grid/GridCreationItemDetailsLayout.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/core/ui/components/grid/GridCreationItemDetailsLayout.kt
@@ -1,10 +1,9 @@
-package com.stoyanvuchev.magicmessage.presentation.main.home_screen
+package com.stoyanvuchev.magicmessage.core.ui.components.grid
 
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.ExperimentalSharedTransitionApi
 import androidx.compose.animation.SharedTransitionScope
-import androidx.compose.animation.animateContentSize
 import androidx.compose.animation.core.SpringSpec
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
@@ -14,6 +13,7 @@ import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -21,43 +21,32 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.material3.Icon
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
-import com.stoyanvuchev.magicmessage.R
 import com.stoyanvuchev.magicmessage.core.ui.components.bottom_nav_bar.BottomNavBarTokens.NavigationBarHeight
-import com.stoyanvuchev.magicmessage.core.ui.components.list.ListItemOption
 import com.stoyanvuchev.magicmessage.core.ui.effect.defaultHazeEffect
-import com.stoyanvuchev.magicmessage.core.ui.event.NavigationEvent
 import com.stoyanvuchev.magicmessage.domain.model.CreationModel
-import dev.chrisbanes.haze.HazeState
 
 @OptIn(ExperimentalSharedTransitionApi::class)
 @Composable
-fun SharedTransitionScope.HomeScreenItemDetails(
-    modifier: Modifier = Modifier,
+fun SharedTransitionScope.GridCreationItemDetailsLayout(
     creation: CreationModel?,
     innerPadding: PaddingValues,
-    hazeState: HazeState,
     boundsTransform: (Rect, Rect) -> SpringSpec<Rect>,
     canvasSize: IntSize,
     onDismiss: () -> Unit,
-    onUIAction: (HomeScreenUIAction) -> Unit,
-    onNavigationEvent: (NavigationEvent) -> Unit
+    onCreationClick: (CreationModel) -> Unit,
+    actions: @Composable ColumnScope.() -> Unit
 ) {
 
     val isBackgroundVisible by rememberUpdatedState(creation != null)
@@ -74,17 +63,19 @@ fun SharedTransitionScope.HomeScreenItemDetails(
                 .fillMaxSize()
                 .navigationBarsPadding()
                 .padding(bottom = NavigationBarHeight)
-                .defaultHazeEffect(hazeState = hazeState)
+                .defaultHazeEffect()
                 .padding(top = innerPadding.calculateTopPadding())
         )
 
     }
 
     AnimatedContent(
-        modifier = modifier,
+        modifier = Modifier
+            .padding(bottom = NavigationBarHeight)
+            .fillMaxSize(),
         targetState = creation,
         transitionSpec = remember { { fadeIn() togetherWith fadeOut() } },
-        label = "HomeScreenItemDetails"
+        label = "GridItemDetailsLayoutAnimatedContent"
     ) { sharedCreation ->
 
         if (sharedCreation != null) {
@@ -115,7 +106,7 @@ fun SharedTransitionScope.HomeScreenItemDetails(
                     }
                 }
 
-                HomeScreenCreationItem(
+                GridCreationItem(
                     modifier = Modifier
                         .size(dpSize)
                         .sharedElement(
@@ -126,87 +117,13 @@ fun SharedTransitionScope.HomeScreenItemDetails(
                             boundsTransform = boundsTransform,
                         ),
                     creation = sharedCreation,
-                    onNavigationEvent = onNavigationEvent,
-                    onLongClick = remember { {} }
+                    onCreationClick = onCreationClick,
+                    onCreationLongClick = remember { { _, _ -> } }
                 )
 
                 Spacer(modifier = Modifier.height(64.dp))
 
-                if (sharedCreation.isDraft) {
-
-                    ListItemOption(
-                        modifier = Modifier.padding(horizontal = 32.dp),
-                        onClick = remember {
-                            {
-                                onUIAction(HomeScreenUIAction.ExportGif(sharedCreation))
-                                onDismiss()
-                            }
-                        },
-                        hazeState = hazeState,
-                        label = { Text(text = "Export GIF") },
-                        icon = {
-
-                            Icon(
-                                modifier = Modifier.size(24.dp),
-                                painter = painterResource(R.drawable.export),
-                                contentDescription = null
-                            )
-
-                        }
-                    )
-
-                    Spacer(modifier = Modifier.height(8.dp))
-
-                }
-
-                var isFavorite by remember { mutableStateOf(sharedCreation.isFavorite) }
-
-                ListItemOption(
-                    modifier = Modifier.padding(horizontal = 32.dp),
-                    onClick = remember { { isFavorite = !isFavorite } },
-                    hazeState = hazeState,
-                    label = {
-
-                        Text(
-                            modifier = Modifier.animateContentSize(
-                                alignment = Alignment.Center
-                            ),
-                            text = if (isFavorite) "Remove from Favorite"
-                            else "Add to Favorite"
-                        )
-
-                    },
-                    icon = {
-
-                        Icon(
-                            modifier = Modifier.size(24.dp),
-                            painter = painterResource(
-                                if (isFavorite) R.drawable.favorite_filled
-                                else R.drawable.favorite_outlined
-                            ),
-                            contentDescription = null
-                        )
-
-                    }
-                )
-
-                Spacer(modifier = Modifier.height(8.dp))
-
-                ListItemOption(
-                    modifier = Modifier.padding(horizontal = 32.dp),
-                    onClick = remember { {} },
-                    hazeState = hazeState,
-                    label = { Text(text = "Move to Trash") },
-                    icon = {
-
-                        Icon(
-                            modifier = Modifier.size(24.dp),
-                            painter = painterResource(R.drawable.delete),
-                            contentDescription = null
-                        )
-
-                    }
-                )
+                actions()
 
             }
 

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/core/ui/components/grid/GridOfCreationItems.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/core/ui/components/grid/GridOfCreationItems.kt
@@ -1,0 +1,78 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2025 Stoyan Vuchev
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES, OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.stoyanvuchev.magicmessage.core.ui.components.grid
+
+import androidx.compose.animation.ExperimentalSharedTransitionApi
+import androidx.compose.animation.SharedTransitionLayout
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.GridItemSpan
+import androidx.compose.foundation.lazy.grid.LazyGridScope
+import androidx.compose.foundation.lazy.grid.LazyGridState
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.stoyanvuchev.magicmessage.core.ui.ext.LocalHazeState
+import dev.chrisbanes.haze.hazeSource
+
+@OptIn(ExperimentalSharedTransitionApi::class)
+@Composable
+fun GridOfCreationItems(
+    lazyGridState: LazyGridState,
+    innerPadding: PaddingValues,
+    hazeSourceKey: String,
+    content: LazyGridScope.() -> Unit
+) = SharedTransitionLayout {
+
+    LazyVerticalGrid(
+        modifier = Modifier
+            .fillMaxSize()
+            .hazeSource(
+                state = LocalHazeState.current,
+                key = hazeSourceKey
+            ),
+        contentPadding = innerPadding,
+        state = lazyGridState,
+        columns = GridCells.Fixed(2),
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+
+        content()
+
+        item(
+            span = { GridItemSpan(this.maxLineSpan) }
+        ) {
+            Spacer(modifier = Modifier.height(164.dp))
+        }
+
+    }
+
+}

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/core/ui/components/grid/GridOfCreationItemsSection.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/core/ui/components/grid/GridOfCreationItemsSection.kt
@@ -1,0 +1,137 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2025 Stoyan Vuchev
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES, OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.stoyanvuchev.magicmessage.core.ui.components.grid
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.ExperimentalSharedTransitionApi
+import androidx.compose.animation.SharedTransitionScope
+import androidx.compose.animation.core.SpringSpec
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.grid.GridItemSpan
+import androidx.compose.foundation.lazy.grid.LazyGridScope
+import androidx.compose.foundation.lazy.grid.itemsIndexed
+import androidx.compose.material3.Text
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.dp
+import com.stoyanvuchev.magicmessage.core.ui.etc.CANVAS_ASPECT_RATIO
+import com.stoyanvuchev.magicmessage.core.ui.etc.UIString
+import com.stoyanvuchev.magicmessage.core.ui.theme.Theme
+import com.stoyanvuchev.magicmessage.domain.model.CreationModel
+
+@OptIn(ExperimentalSharedTransitionApi::class)
+fun LazyGridScope.gridOfCreationItemsSection(
+    sharedTransitionScope: SharedTransitionScope,
+    label: UIString,
+    items: List<CreationModel>,
+    categoryKey: String,
+    sharedCreation: CreationModel?,
+    boundsTransform: (Rect, Rect) -> SpringSpec<Rect>,
+    onCreationClick: (CreationModel) -> Unit,
+    onCreationLongClick: (CreationModel, IntSize) -> Unit
+) = with(sharedTransitionScope) {
+
+    item(
+        span = { GridItemSpan(this.maxLineSpan) }
+    ) {
+
+        Spacer(modifier = Modifier.height(12.dp))
+
+        Text(
+            modifier = Modifier
+                .padding(horizontal = 24.dp)
+                .padding(top = 24.dp),
+            text = label.asString(),
+            style = Theme.typefaces.bodySmall,
+            color = Theme.colors.onSurfaceElevationLow.copy(.5f)
+        )
+
+        Spacer(modifier = Modifier.height(0.dp))
+
+    }
+
+    itemsIndexed(
+        items = items,
+        key = { _, creation -> "${categoryKey}_${creation.createdAt}" }
+    ) { i, creation ->
+
+        val startPadding by remember(i) {
+            derivedStateOf { if (i % 2 == 0) 24.dp else 0.dp }
+        }
+
+        val endPadding by remember(i) {
+            derivedStateOf { if (i % 2 == 0) 0.dp else 24.dp }
+        }
+
+        val visible by rememberUpdatedState(
+            sharedCreation?.id != creation.id
+        )
+
+        AnimatedVisibility(
+            modifier = Modifier
+                .animateItem()
+                .padding(
+                    start = startPadding,
+                    end = endPadding
+                )
+                .fillMaxWidth()
+                .aspectRatio(ratio = CANVAS_ASPECT_RATIO),
+            visible = visible,
+            enter = fadeIn(),
+            exit = fadeOut()
+        ) {
+
+            GridCreationItem(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .sharedElement(
+                        sharedContentState = rememberSharedContentState(
+                            key = creation.id ?: 0
+                        ),
+                        animatedVisibilityScope = this@AnimatedVisibility,
+                        boundsTransform = boundsTransform,
+                    ),
+                creation = creation,
+                onCreationClick = onCreationClick,
+                onCreationLongClick = onCreationLongClick
+            )
+
+        }
+
+    }
+
+}

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/core/ui/components/list/ListItemOption.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/core/ui/components/list/ListItemOption.kt
@@ -44,13 +44,11 @@ import androidx.compose.ui.unit.dp
 import com.stoyanvuchev.magicmessage.core.ui.components.interaction.rememberRipple
 import com.stoyanvuchev.magicmessage.core.ui.effect.defaultHazeEffect
 import com.stoyanvuchev.magicmessage.core.ui.theme.Theme
-import dev.chrisbanes.haze.HazeState
 
 @Composable
 fun ListItemOption(
     modifier: Modifier = Modifier,
     onClick: () -> Unit,
-    hazeState: HazeState,
     label: @Composable () -> Unit,
     icon: @Composable (() -> Unit)? = null
 ) {
@@ -69,7 +67,7 @@ fun ListItemOption(
                     indication = rememberRipple(),
                     onClick = onClick
                 )
-                .defaultHazeEffect(hazeState = hazeState)
+                .defaultHazeEffect()
                 .background(Theme.colors.surfaceElevationHigh.copy(.5f))
                 .border(
                     width = 1.dp,

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/core/ui/components/top_bar/TopBar.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/core/ui/components/top_bar/TopBar.kt
@@ -43,10 +43,11 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.unit.dp
+import com.stoyanvuchev.magicmessage.core.ui.components.top_bar.TopBarTokens.TopBarActionHorizontalPadding
 import com.stoyanvuchev.magicmessage.core.ui.components.top_bar.TopBarTokens.TopBarActionItemsHorizontalPadding
 import com.stoyanvuchev.magicmessage.core.ui.components.top_bar.TopBarTokens.TopBarHeight
-import com.stoyanvuchev.magicmessage.core.ui.components.top_bar.TopBarTokens.TopBarActionHorizontalPadding
 import com.stoyanvuchev.magicmessage.core.ui.components.top_bar.TopBarTokens.TopBarTitleHorizontalPadding
+import com.stoyanvuchev.magicmessage.core.ui.effect.defaultHazeEffect
 import com.stoyanvuchev.magicmessage.core.ui.theme.Theme
 
 @Composable
@@ -56,60 +57,57 @@ fun TopBar(
     navigationAction: @Composable (() -> Unit)? = null,
     actions: @Composable (RowScope.() -> Unit)? = null,
     windowInsets: WindowInsets = WindowInsets.statusBars
+) = Column(
+    modifier = Modifier
+        .fillMaxWidth()
+        .defaultHazeEffect()
+        .clipToBounds()
+        .then(modifier)
 ) {
 
-    Column(
+    Row(
         modifier = Modifier
+            .windowInsetsPadding(windowInsets)
             .fillMaxWidth()
-            .clipToBounds()
-            .then(modifier)
+            .height(TopBarHeight),
+        verticalAlignment = Alignment.CenterVertically
     ) {
 
-        Row(
-            modifier = Modifier
-                .windowInsetsPadding(windowInsets)
-                .fillMaxWidth()
-                .height(TopBarHeight),
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-
-            if (navigationAction != null) {
-                Spacer(modifier = Modifier.width(TopBarActionHorizontalPadding))
-                navigationAction()
-                Spacer(modifier = Modifier.width(TopBarActionHorizontalPadding))
-            } else {
-                Spacer(modifier = Modifier.width(TopBarTitleHorizontalPadding))
-            }
-
-            CompositionLocalProvider(
-                LocalTextStyle provides Theme.typefaces.titleSmall,
-                content = title
-            )
-
+        if (navigationAction != null) {
+            Spacer(modifier = Modifier.width(TopBarActionHorizontalPadding))
+            navigationAction()
+            Spacer(modifier = Modifier.width(TopBarActionHorizontalPadding))
+        } else {
             Spacer(modifier = Modifier.width(TopBarTitleHorizontalPadding))
-
-            if (actions != null) {
-                Row(
-                    modifier = Modifier.weight(1f),
-                    horizontalArrangement = Arrangement
-                        .spacedBy(
-                            TopBarActionItemsHorizontalPadding,
-                            Alignment.End
-                        ),
-                    verticalAlignment = Alignment.CenterVertically,
-                    content = actions
-                )
-                Spacer(modifier = Modifier.width(TopBarActionHorizontalPadding))
-            }
-
         }
 
-        HorizontalDivider(
-            modifier = Modifier.fillMaxWidth(),
-            color = Theme.colors.outline,
-            thickness = 1.dp
+        CompositionLocalProvider(
+            LocalTextStyle provides Theme.typefaces.titleSmall,
+            content = title
         )
 
+        Spacer(modifier = Modifier.width(TopBarTitleHorizontalPadding))
+
+        if (actions != null) {
+            Row(
+                modifier = Modifier.weight(1f),
+                horizontalArrangement = Arrangement
+                    .spacedBy(
+                        TopBarActionItemsHorizontalPadding,
+                        Alignment.End
+                    ),
+                verticalAlignment = Alignment.CenterVertically,
+                content = actions
+            )
+            Spacer(modifier = Modifier.width(TopBarActionHorizontalPadding))
+        }
+
     }
+
+    HorizontalDivider(
+        modifier = Modifier.fillMaxWidth(),
+        color = Theme.colors.outline,
+        thickness = 1.dp
+    )
 
 }

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/core/ui/effect/DefaultHazeEffect.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/core/ui/effect/DefaultHazeEffect.kt
@@ -24,28 +24,28 @@
 
 package com.stoyanvuchev.magicmessage.core.ui.effect
 
+import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.composed
 import androidx.compose.ui.unit.dp
+import com.stoyanvuchev.magicmessage.core.ui.ext.LocalHazeState
 import com.stoyanvuchev.magicmessage.core.ui.theme.Theme
 import dev.chrisbanes.haze.HazeState
 import dev.chrisbanes.haze.HazeStyle
 import dev.chrisbanes.haze.HazeTint
 import dev.chrisbanes.haze.hazeEffect
 
+@Composable
 fun Modifier.defaultHazeEffect(
-    hazeState: HazeState
+    hazeState: HazeState = LocalHazeState.current
 ): Modifier {
-    return composed {
-        hazeEffect(
-            state = hazeState,
-            style = HazeStyle(
-                tint = HazeTint(color = Theme.colors.surfaceElevationLow.copy(.75f)),
-                blurRadius = 16.dp,
-                noiseFactor = -1f,
-                backgroundColor = Theme.colors.surfaceElevationLow
+    return hazeEffect(
+        state = hazeState,
+        style = HazeStyle(
+            tint = HazeTint(color = Theme.colors.surfaceElevationLow.copy(.75f)),
+            blurRadius = 16.dp,
+            noiseFactor = -1f,
+            backgroundColor = Theme.colors.surfaceElevationLow
 
-            )
         )
-    }
+    )
 }

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/core/ui/etc/CanvasAspectRatio.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/core/ui/etc/CanvasAspectRatio.kt
@@ -22,19 +22,6 @@
  * SOFTWARE.
  */
 
-package com.stoyanvuchev.magicmessage.domain.model
+package com.stoyanvuchev.magicmessage.core.ui.etc
 
-import androidx.compose.runtime.Stable
-import androidx.compose.ui.graphics.Color
-import com.stoyanvuchev.magicmessage.domain.brush.BrushEffect
-import com.stoyanvuchev.magicmessage.domain.serializer.ColorSerializer
-import kotlinx.serialization.Serializable
-
-@Serializable
-@Stable
-data class StrokeModel(
-    val points: List<TimedPoint>,
-    @Serializable(with = ColorSerializer::class) val color: Color,
-    val width: Float,
-    val effect: BrushEffect = BrushEffect.NONE
-)
+const val CANVAS_ASPECT_RATIO = 3f / 4f

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/core/ui/etc/UIString.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/core/ui/etc/UIString.kt
@@ -22,19 +22,39 @@
  * SOFTWARE.
  */
 
-package com.stoyanvuchev.magicmessage.domain.model
+package com.stoyanvuchev.magicmessage.core.ui.etc
 
+import android.content.Context
+import androidx.annotation.StringRes
+import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
-import androidx.compose.ui.graphics.Color
-import com.stoyanvuchev.magicmessage.domain.brush.BrushEffect
-import com.stoyanvuchev.magicmessage.domain.serializer.ColorSerializer
-import kotlinx.serialization.Serializable
+import androidx.compose.ui.res.stringResource
 
-@Serializable
 @Stable
-data class StrokeModel(
-    val points: List<TimedPoint>,
-    @Serializable(with = ColorSerializer::class) val color: Color,
-    val width: Float,
-    val effect: BrushEffect = BrushEffect.NONE
-)
+sealed interface UIString {
+
+    data class Basic(
+        val value: String
+    ) : UIString
+
+    class Resource(
+        @param:StringRes val resId: Int,
+        vararg val args: Any
+    ) : UIString
+
+    @Composable
+    fun asString(): String {
+        return when (this) {
+            is Basic -> value
+            is Resource -> stringResource(resId, *args)
+        }
+    }
+
+    fun asString(context: Context): String {
+        return when (this) {
+            is Basic -> value
+            is Resource -> context.getString(resId, *args)
+        }
+    }
+
+}

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/core/ui/ext/HazeStateExt.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/core/ui/ext/HazeStateExt.kt
@@ -22,19 +22,11 @@
  * SOFTWARE.
  */
 
-package com.stoyanvuchev.magicmessage.domain.model
+package com.stoyanvuchev.magicmessage.core.ui.ext
 
-import androidx.compose.runtime.Stable
-import androidx.compose.ui.graphics.Color
-import com.stoyanvuchev.magicmessage.domain.brush.BrushEffect
-import com.stoyanvuchev.magicmessage.domain.serializer.ColorSerializer
-import kotlinx.serialization.Serializable
+import androidx.compose.runtime.compositionLocalOf
+import dev.chrisbanes.haze.HazeState
 
-@Serializable
-@Stable
-data class StrokeModel(
-    val points: List<TimedPoint>,
-    @Serializable(with = ColorSerializer::class) val color: Color,
-    val width: Float,
-    val effect: BrushEffect = BrushEffect.NONE
-)
+val LocalHazeState = compositionLocalOf {
+    HazeState(initialBlurEnabled = true)
+}

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/core/ui/theme/UIWrapper.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/core/ui/theme/UIWrapper.kt
@@ -29,6 +29,7 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberUpdatedState
+import com.stoyanvuchev.magicmessage.core.ui.ext.LocalHazeState
 import com.stoyanvuchev.magicmessage.core.ui.theme.color.ColorPalette
 import com.stoyanvuchev.magicmessage.core.ui.theme.color.LocalColorPalette
 import com.stoyanvuchev.magicmessage.core.ui.theme.color.LocalContentColor
@@ -41,6 +42,7 @@ import com.stoyanvuchev.magicmessage.core.ui.theme.typeface.LocalTextStyle
 import com.stoyanvuchev.magicmessage.core.ui.theme.typeface.LocalTypefaces
 import com.stoyanvuchev.magicmessage.core.ui.theme.typeface.Typefaces
 import com.stoyanvuchev.systemuibarstweaker.ProvideSystemUIBarsTweaker
+import dev.chrisbanes.haze.rememberHazeState
 
 @Composable
 fun UIWrapper(
@@ -52,6 +54,7 @@ fun UIWrapper(
     content: @Composable () -> Unit
 ) = ProvideSystemUIBarsTweaker {
 
+    val hazeState = rememberHazeState()
     val finalColorPalette by rememberUpdatedState(
         if (animateColorPalette) colorPalette.asAnimatedColorPalette()
         else colorPalette
@@ -64,6 +67,7 @@ fun UIWrapper(
         LocalTypefaces provides typefaces,
         LocalTextStyle provides typefaces.bodyMedium,
         LocalShapes provides shapes,
+        LocalHazeState provides hazeState,
         content = content
     )
 

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/data/local/CreationDao.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/data/local/CreationDao.kt
@@ -44,19 +44,41 @@ interface CreationDao {
     @Delete
     suspend fun delete(creation: CreationEntity)
 
-    @Query("SELECT * FROM creations WHERE isDraft IS FALSE ORDER BY createdAt DESC")
-    fun getAll(): Flow<List<CreationEntity>>
-
-    @Query("SELECT * FROM creations WHERE isDraft IS TRUE ORDER BY createdAt DESC")
-    fun getAllDrafts(): Flow<List<CreationEntity>>
-
-    @Query("SELECT * FROM creations WHERE id = :id")
-    suspend fun getById(id: Long): CreationEntity?
-
     @Query("DELETE FROM creations WHERE isDraft IS 1")
     suspend fun deleteAllDrafts()
 
     @Query("DELETE FROM creations")
     suspend fun deleteAllCreations()
+
+    // Exported
+
+    fun getAll(onlyFavorite: Boolean = false): Flow<List<CreationEntity>> {
+        return if (onlyFavorite) getAllExportedFavorite()
+        else getAllExported()
+    }
+
+    @Query("SELECT * FROM creations WHERE isDraft IS FALSE AND isFavorite IS TRUE ORDER BY createdAt DESC")
+    fun getAllExportedFavorite(): Flow<List<CreationEntity>>
+
+    @Query("SELECT * FROM creations WHERE isDraft IS FALSE ORDER BY createdAt DESC")
+    fun getAllExported(): Flow<List<CreationEntity>>
+
+    // Drafts
+
+    fun getAllDrafts(onlyFavorite: Boolean = false): Flow<List<CreationEntity>> {
+        return if (onlyFavorite) getAllFavoriteDrafts()
+        else getDrafts()
+    }
+
+    @Query("SELECT * FROM creations WHERE isDraft IS TRUE ORDER BY createdAt DESC")
+    fun getDrafts(): Flow<List<CreationEntity>>
+
+    @Query("SELECT * FROM creations WHERE isDraft IS TRUE AND isFavorite IS TRUE ORDER BY createdAt DESC")
+    fun getAllFavoriteDrafts(): Flow<List<CreationEntity>>
+
+    // By ID
+
+    @Query("SELECT * FROM creations WHERE id = :id")
+    suspend fun getById(id: Long): CreationEntity?
 
 }

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/data/repository/CreationRepositoryImpl.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/data/repository/CreationRepositoryImpl.kt
@@ -29,7 +29,6 @@ import com.stoyanvuchev.magicmessage.data.local.CreationEntity
 import com.stoyanvuchev.magicmessage.domain.model.CreationModel
 import com.stoyanvuchev.magicmessage.domain.model.DrawConfiguration
 import com.stoyanvuchev.magicmessage.domain.model.DrawingSnapshot
-import com.stoyanvuchev.magicmessage.domain.model.StrokeModel
 import com.stoyanvuchev.magicmessage.domain.repository.CreationRepository
 import com.stoyanvuchev.magicmessage.mappers.toModel
 import kotlinx.coroutines.flow.Flow
@@ -87,12 +86,12 @@ class CreationRepositoryImpl @Inject constructor(
         dao.update(creation.copy(isFavorite = false))
     }
 
-    override fun getDrafts(): Flow<List<CreationModel>> {
-        return dao.getAllDrafts().map { it.map { e -> e.toModel() } }
+    override fun getDrafts(onlyFavorite: Boolean): Flow<List<CreationModel>> {
+        return dao.getAllDrafts(onlyFavorite).map { it.map { e -> e.toModel() } }
     }
 
-    override fun getFinished(): Flow<List<CreationModel>> {
-        return dao.getAll().map { it.map { e -> e.toModel() } }
+    override fun getFinished(onlyFavorite: Boolean): Flow<List<CreationModel>> {
+        return dao.getAll(onlyFavorite).map { it.map { e -> e.toModel() } }
     }
 
     override suspend fun getById(id: Long): CreationModel? {

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/di/CreationModule.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/di/CreationModule.kt
@@ -34,6 +34,8 @@ import com.stoyanvuchev.magicmessage.domain.usecase.CreationGetByIdUseCase
 import com.stoyanvuchev.magicmessage.domain.usecase.CreationGetDraftsUseCase
 import com.stoyanvuchev.magicmessage.domain.usecase.CreationGetExportedUseCase
 import com.stoyanvuchev.magicmessage.domain.usecase.CreationMarkAsExportedUseCase
+import com.stoyanvuchev.magicmessage.domain.usecase.CreationMarkAsFavoriteUseCase
+import com.stoyanvuchev.magicmessage.domain.usecase.CreationRemoveAsFavoriteUseCase
 import com.stoyanvuchev.magicmessage.domain.usecase.CreationSaveOrUpdateUseCase
 import com.stoyanvuchev.magicmessage.domain.usecase.CreationUseCases
 import dagger.Module
@@ -81,7 +83,9 @@ object CreationModule {
             getByIdUseCase = CreationGetByIdUseCase(repository),
             getExportedUseCase = CreationGetExportedUseCase(repository),
             getDraftsUseCase = CreationGetDraftsUseCase(repository),
-            markAsExportedUseCase = CreationMarkAsExportedUseCase(repository)
+            markAsExportedUseCase = CreationMarkAsExportedUseCase(repository),
+            markAsFavoriteUseCase = CreationMarkAsFavoriteUseCase(repository),
+            removeAsFavoriteUseCase = CreationRemoveAsFavoriteUseCase(repository)
         )
     }
 

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/domain/DefaultBGLayers.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/domain/DefaultBGLayers.kt
@@ -24,11 +24,11 @@
 
 package com.stoyanvuchev.magicmessage.domain
 
-import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.Stable
 import androidx.compose.ui.graphics.Color
 import com.stoyanvuchev.magicmessage.domain.layer.BackgroundLayer
 
-@Immutable
+@Stable
 object DefaultBGLayers {
 
     val colorLayers: List<BackgroundLayer.ColorLayer> = defaultDrawColors

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/domain/brush/BrushEffect.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/domain/brush/BrushEffect.kt
@@ -24,4 +24,7 @@
 
 package com.stoyanvuchev.magicmessage.domain.brush
 
+import androidx.compose.runtime.Stable
+
+@Stable
 enum class BrushEffect { NONE, BUBBLES, STARS, HEARTS }

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/domain/brush/BrushThickness.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/domain/brush/BrushThickness.kt
@@ -24,9 +24,11 @@
 
 package com.stoyanvuchev.magicmessage.domain.brush
 
+import androidx.compose.runtime.Stable
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 
+@Stable
 enum class BrushThickness(
     val thickness: Dp
 ) {

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/domain/repository/CreationRepository.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/domain/repository/CreationRepository.kt
@@ -42,8 +42,8 @@ interface CreationRepository {
     suspend fun markAsFavorite(id: Long)
     suspend fun removeAsFavorite(id: Long)
 
-    fun getDrafts(): Flow<List<CreationModel>>
-    fun getFinished(): Flow<List<CreationModel>>
+    fun getDrafts(onlyFavorite: Boolean): Flow<List<CreationModel>>
+    fun getFinished(onlyFavorite: Boolean): Flow<List<CreationModel>>
     suspend fun getById(id: Long): CreationModel?
 
     suspend fun deleteAllDrafts()

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/domain/usecase/CreationGetDraftsUseCase.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/domain/usecase/CreationGetDraftsUseCase.kt
@@ -33,8 +33,10 @@ class CreationGetDraftsUseCase @Inject constructor(
     private val repository: CreationRepository
 ) {
 
-    operator fun invoke(): Flow<List<CreationModel>> {
-        return repository.getDrafts()
+    operator fun invoke(
+        onlyFavorite: Boolean = false
+    ): Flow<List<CreationModel>> {
+        return repository.getDrafts(onlyFavorite)
     }
 
 }

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/domain/usecase/CreationGetExportedUseCase.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/domain/usecase/CreationGetExportedUseCase.kt
@@ -33,8 +33,10 @@ class CreationGetExportedUseCase @Inject constructor(
     private val repository: CreationRepository
 ) {
 
-    operator fun invoke(): Flow<List<CreationModel>> {
-        return repository.getFinished()
+    operator fun invoke(
+        onlyFavorite: Boolean = false
+    ): Flow<List<CreationModel>> {
+        return repository.getFinished(onlyFavorite)
     }
 
 }

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/domain/usecase/CreationMarkAsFavoriteUseCase.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/domain/usecase/CreationMarkAsFavoriteUseCase.kt
@@ -22,19 +22,19 @@
  * SOFTWARE.
  */
 
-package com.stoyanvuchev.magicmessage.domain.model
+package com.stoyanvuchev.magicmessage.domain.usecase
 
-import androidx.compose.runtime.Stable
-import androidx.compose.ui.graphics.Color
-import com.stoyanvuchev.magicmessage.domain.brush.BrushEffect
-import com.stoyanvuchev.magicmessage.domain.serializer.ColorSerializer
-import kotlinx.serialization.Serializable
+import com.stoyanvuchev.magicmessage.domain.repository.CreationRepository
+import javax.inject.Inject
 
-@Serializable
-@Stable
-data class StrokeModel(
-    val points: List<TimedPoint>,
-    @Serializable(with = ColorSerializer::class) val color: Color,
-    val width: Float,
-    val effect: BrushEffect = BrushEffect.NONE
-)
+class CreationMarkAsFavoriteUseCase @Inject constructor(
+    private val repository: CreationRepository
+) {
+
+    suspend operator fun invoke(creationId: Long?) {
+        if (creationId != null) {
+            repository.markAsFavorite(creationId)
+        }
+    }
+
+}

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/domain/usecase/CreationRemoveAsFavoriteUseCase.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/domain/usecase/CreationRemoveAsFavoriteUseCase.kt
@@ -22,19 +22,19 @@
  * SOFTWARE.
  */
 
-package com.stoyanvuchev.magicmessage.domain.model
+package com.stoyanvuchev.magicmessage.domain.usecase
 
-import androidx.compose.runtime.Stable
-import androidx.compose.ui.graphics.Color
-import com.stoyanvuchev.magicmessage.domain.brush.BrushEffect
-import com.stoyanvuchev.magicmessage.domain.serializer.ColorSerializer
-import kotlinx.serialization.Serializable
+import com.stoyanvuchev.magicmessage.domain.repository.CreationRepository
+import javax.inject.Inject
 
-@Serializable
-@Stable
-data class StrokeModel(
-    val points: List<TimedPoint>,
-    @Serializable(with = ColorSerializer::class) val color: Color,
-    val width: Float,
-    val effect: BrushEffect = BrushEffect.NONE
-)
+class CreationRemoveAsFavoriteUseCase @Inject constructor(
+    private val repository: CreationRepository
+) {
+
+    suspend operator fun invoke(creationId: Long?) {
+        if (creationId != null) {
+            repository.removeAsFavorite(creationId)
+        }
+    }
+
+}

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/domain/usecase/CreationUseCases.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/domain/usecase/CreationUseCases.kt
@@ -29,5 +29,7 @@ data class CreationUseCases(
     val getByIdUseCase: CreationGetByIdUseCase,
     val getExportedUseCase: CreationGetExportedUseCase,
     val getDraftsUseCase: CreationGetDraftsUseCase,
-    val markAsExportedUseCase: CreationMarkAsExportedUseCase
+    val markAsExportedUseCase: CreationMarkAsExportedUseCase,
+    val markAsFavoriteUseCase: CreationMarkAsFavoriteUseCase,
+    val removeAsFavoriteUseCase: CreationRemoveAsFavoriteUseCase
 )

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/framework/service/ExportGifServiceIntent.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/framework/service/ExportGifServiceIntent.kt
@@ -22,19 +22,30 @@
  * SOFTWARE.
  */
 
-package com.stoyanvuchev.magicmessage.domain.model
+package com.stoyanvuchev.magicmessage.framework.service
 
-import androidx.compose.runtime.Stable
-import androidx.compose.ui.graphics.Color
-import com.stoyanvuchev.magicmessage.domain.brush.BrushEffect
-import com.stoyanvuchev.magicmessage.domain.serializer.ColorSerializer
-import kotlinx.serialization.Serializable
+import android.content.Context
+import android.content.Intent
+import androidx.core.content.ContextCompat
 
-@Serializable
-@Stable
-data class StrokeModel(
-    val points: List<TimedPoint>,
-    @Serializable(with = ColorSerializer::class) val color: Color,
-    val width: Float,
-    val effect: BrushEffect = BrushEffect.NONE
-)
+object ExportGifServiceIntent {
+
+    fun start(
+        context: Context,
+        messageId: Long?,
+        width: Int,
+        height: Int
+    ) {
+
+        val intent = Intent(context, ExportGifService::class.java)
+            .apply {
+                putExtra("messageId", messageId)
+                putExtra("width", width)
+                putExtra("height", height)
+            }
+
+        ContextCompat.startForegroundService(context, intent)
+
+    }
+
+}

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/AppBottomNavBar.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/AppBottomNavBar.kt
@@ -47,17 +47,11 @@ import androidx.navigation.NavHostController
 import androidx.navigation.compose.currentBackStackEntryAsState
 import com.stoyanvuchev.magicmessage.core.ui.components.bottom_nav_bar.BottomNavBar
 import com.stoyanvuchev.magicmessage.core.ui.components.bottom_nav_bar.BottomNavBarItem
-import com.stoyanvuchev.magicmessage.core.ui.effect.defaultHazeEffect
 import com.stoyanvuchev.magicmessage.presentation.main.MainScreen
 import com.stoyanvuchev.magicmessage.presentation.main.mainScreenNavDestinations
-import dev.chrisbanes.haze.HazeState
 
 @Composable
-fun AppBottomNavBar(
-    modifier: Modifier = Modifier,
-    navController: NavHostController,
-    hazeState: HazeState
-) {
+fun AppBottomNavBar(navController: NavHostController) {
 
     val destinations = rememberSaveable { mainScreenNavDestinations }
     val navBackStackEntry by navController.currentBackStackEntryAsState()
@@ -74,17 +68,13 @@ fun AppBottomNavBar(
     }
 
     AnimatedVisibility(
-        modifier = Modifier
-            .fillMaxWidth()
-            .then(modifier),
+        modifier = Modifier.fillMaxWidth(),
         visible = isNavBarVisible,
         enter = remember { fadeIn() + slideInVertically { it } },
         exit = remember { slideOutVertically { it } + fadeOut() }
     ) {
 
-        BottomNavBar(
-            modifier = Modifier.defaultHazeEffect(hazeState = hazeState)
-        ) {
+        BottomNavBar {
 
             destinations.forEachIndexed { index, destination ->
 

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/AppNavHost.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/AppNavHost.kt
@@ -26,7 +26,6 @@ package com.stoyanvuchev.magicmessage.presentation
 
 import android.annotation.SuppressLint
 import android.net.Uri
-import androidx.compose.animation.ExperimentalSharedTransitionApi
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
@@ -44,14 +43,8 @@ import com.stoyanvuchev.magicmessage.presentation.boarding.BoardingScreen
 import com.stoyanvuchev.magicmessage.presentation.boarding.boardingNavGraph
 import com.stoyanvuchev.magicmessage.presentation.main.MainScreen
 import com.stoyanvuchev.magicmessage.presentation.main.mainNavGraph
-import dev.chrisbanes.haze.hazeSource
-import dev.chrisbanes.haze.rememberHazeState
 
-@OptIn(ExperimentalSharedTransitionApi::class)
-@SuppressLint(
-    "UnusedMaterial3ScaffoldPaddingParameter",
-    "UnusedContentLambdaTargetStateParameter"
-)
+@SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
 @Composable
 fun AppNavHost(
     isBoardingComplete: Boolean?,
@@ -62,29 +55,15 @@ fun AppNavHost(
     onDismissExportDialog: () -> Unit
 ) {
 
-    val hazeState = rememberHazeState()
-
     Scaffold(
         modifier = Modifier.fillMaxSize(),
         containerColor = Theme.colors.surfaceElevationLow,
         contentColor = Theme.colors.onSurfaceElevationLow,
-        bottomBar = {
-
-            AppBottomNavBar(
-                navController = navController,
-                hazeState = hazeState
-            )
-
-        }
+        bottomBar = { AppBottomNavBar(navController = navController) }
     ) { _ ->
 
         NavHost(
-            modifier = Modifier
-                .fillMaxSize()
-                .hazeSource(
-                    state = hazeState,
-                    key = "root_haze_source"
-                ),
+            modifier = Modifier.fillMaxSize(),
             enterTransition = remember { { DefaultNavigationTransitions.enter(this) } },
             exitTransition = remember { { DefaultNavigationTransitions.exit(this) } },
             popEnterTransition = remember { { DefaultNavigationTransitions.popEnter(this) } },
@@ -120,7 +99,6 @@ fun AppNavHost(
             exporterProgress = exporterProgress,
             exporterState = exporterState,
             exportedUri = exportedUri,
-            hazeState = hazeState,
             onDismissExportDialog = onDismissExportDialog
         )
 

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/ExportDialog.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/ExportDialog.kt
@@ -66,14 +66,12 @@ import com.stoyanvuchev.magicmessage.R
 import com.stoyanvuchev.magicmessage.core.ui.effect.defaultHazeEffect
 import com.stoyanvuchev.magicmessage.core.ui.theme.Theme
 import com.stoyanvuchev.magicmessage.framework.export.ExporterState
-import dev.chrisbanes.haze.HazeState
 
 @Composable
 fun ExportDialog(
     exporterProgress: Int,
     exporterState: ExporterState,
     exportedUri: Uri?,
-    hazeState: HazeState,
     onDismissExportDialog: () -> Unit,
 ) {
 
@@ -96,7 +94,7 @@ fun ExportDialog(
                 modifier = Modifier
                     .padding(horizontal = 40.dp)
                     .clip(Theme.shapes.mediumShape)
-                    .defaultHazeEffect(hazeState = hazeState)
+                    .defaultHazeEffect()
                     .border(
                         width = 1.dp,
                         color = Theme.colors.outline,

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/main/draw_screen/DrawScreen.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/main/draw_screen/DrawScreen.kt
@@ -52,6 +52,7 @@ import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.unit.dp
 import com.stoyanvuchev.magicmessage.core.ui.DrawingController
 import com.stoyanvuchev.magicmessage.core.ui.event.NavigationEvent
+import com.stoyanvuchev.magicmessage.core.ui.ext.LocalHazeState
 import com.stoyanvuchev.magicmessage.core.ui.theme.Theme
 import com.stoyanvuchev.magicmessage.core.ui.theme.isInDarkThemeMode
 import com.stoyanvuchev.magicmessage.presentation.main.draw_screen.dialog.DialogEditType
@@ -59,7 +60,6 @@ import com.stoyanvuchev.magicmessage.presentation.main.draw_screen.dialog.DrawSc
 import com.stoyanvuchev.systemuibarstweaker.LocalSystemUIBarsTweaker
 import com.stoyanvuchev.systemuibarstweaker.ScrimStyle
 import dev.chrisbanes.haze.hazeSource
-import dev.chrisbanes.haze.rememberHazeState
 import kotlinx.coroutines.launch
 
 @OptIn(
@@ -74,7 +74,6 @@ fun DrawScreen(
     onNavigationEvent: (NavigationEvent) -> Unit
 ) {
 
-    val hazeState = rememberHazeState()
     val tweaker = LocalSystemUIBarsTweaker.current
     val darkTheme by rememberUpdatedState(isInDarkThemeMode())
     val scope = rememberCoroutineScope()
@@ -118,7 +117,6 @@ fun DrawScreen(
 
             DrawScreenTopBar(
                 state = state,
-                hazeState = hazeState,
                 drawingController = drawingController,
                 onUIAction = onUIAction,
                 onNavigationEvent = onNavigationEvent
@@ -128,7 +126,6 @@ fun DrawScreen(
         bottomBar = {
 
             DrawScreenBottomBar(
-                hazeState = hazeState,
                 state = state,
                 onUIAction = onUIAction
             )
@@ -139,7 +136,10 @@ fun DrawScreen(
         Box(
             modifier = Modifier
                 .fillMaxSize()
-                .hazeSource(state = hazeState)
+                .hazeSource(
+                    state = LocalHazeState.current,
+                    key = "draw_screen_haze_source"
+                )
                 .padding(innerPadding),
             contentAlignment = Alignment.Center
         ) {
@@ -205,7 +205,6 @@ fun DrawScreen(
             type = state.dialogEditType,
             state = state,
             sheetState = sheetState,
-            hazeState = hazeState,
             onUIAction = onUIAction
         )
 

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/main/draw_screen/DrawScreenBottomBar.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/main/draw_screen/DrawScreenBottomBar.kt
@@ -25,8 +25,6 @@
 package com.stoyanvuchev.magicmessage.presentation.main.draw_screen
 
 import androidx.compose.foundation.Canvas
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
@@ -43,162 +41,149 @@ import androidx.compose.ui.unit.dp
 import com.stoyanvuchev.magicmessage.R
 import com.stoyanvuchev.magicmessage.core.ui.components.bottom_bar.BottomBar
 import com.stoyanvuchev.magicmessage.core.ui.components.bottom_bar.BottomBarItem
-import com.stoyanvuchev.magicmessage.core.ui.effect.defaultHazeEffect
 import com.stoyanvuchev.magicmessage.core.ui.theme.Theme
 import com.stoyanvuchev.magicmessage.domain.brush.BrushEffect
 import com.stoyanvuchev.magicmessage.domain.brush.BrushThickness
 import com.stoyanvuchev.magicmessage.presentation.main.draw_screen.dialog.DialogEditType
-import dev.chrisbanes.haze.HazeState
 
 @Composable
 fun DrawScreenBottomBar(
-    hazeState: HazeState,
     state: DrawScreenState,
     onUIAction: (DrawScreenUIAction) -> Unit
-) {
+) = BottomBar {
 
-    Column(modifier = Modifier.fillMaxWidth()) {
+    BottomBarItem(
+        onClick = remember {
+            {
+                onUIAction(
+                    DrawScreenUIAction.SetDialogEditType(
+                        DialogEditType.EFFECT
+                    )
+                )
+            }
+        },
+        label = {
+            Text(text = stringResource(R.string.draw_screen_brush_effect_label))
+        },
+        icon = {
 
-        BottomBar(
-            modifier = Modifier.defaultHazeEffect(hazeState = hazeState)
-        ) {
-
-            BottomBarItem(
-                onClick = remember {
-                    {
-                        onUIAction(
-                            DrawScreenUIAction.SetDialogEditType(
-                                DialogEditType.EFFECT
-                            )
-                        )
+            val icon by rememberUpdatedState(
+                painterResource(
+                    when (state.drawConfiguration.effect) {
+                        BrushEffect.NONE -> R.drawable.swibble_line
+                        BrushEffect.BUBBLES -> R.drawable.swibble_bubbles
+                        BrushEffect.STARS -> R.drawable.swibble_stars
+                        BrushEffect.HEARTS -> R.drawable.swibble_hearts
                     }
-                },
-                label = {
-                    Text(text = stringResource(R.string.draw_screen_brush_effect_label))
-                },
-                icon = {
-
-                    val icon by rememberUpdatedState(
-                        painterResource(
-                            when (state.drawConfiguration.effect) {
-                                BrushEffect.NONE -> R.drawable.swibble_line
-                                BrushEffect.BUBBLES -> R.drawable.swibble_bubbles
-                                BrushEffect.STARS -> R.drawable.swibble_stars
-                                BrushEffect.HEARTS -> R.drawable.swibble_hearts
-                            }
-                        )
-                    )
-
-                    Icon(
-                        painter = icon,
-                        contentDescription = null
-                    )
-
-                }
+                )
             )
 
-            BottomBarItem(
-                onClick = remember {
-                    {
-                        onUIAction(
-                            DrawScreenUIAction.SetDialogEditType(
-                                DialogEditType.THICKNESS
-                            )
-                        )
-                    }
-                },
-                label = {
-                    Text(text = stringResource(R.string.draw_screen_brush_width_label))
-                },
-                icon = {
-
-                    val icon by rememberUpdatedState(
-                        painterResource(
-                            when (state.drawConfiguration.thickness) {
-                                BrushThickness.THIN -> R.drawable.brush_thin
-                                BrushThickness.MEDIUM -> R.drawable.brush_medium
-                                BrushThickness.LARGE -> R.drawable.brush_medium
-                                BrushThickness.THICK -> R.drawable.brush_thick
-                            }
-                        )
-                    )
-
-                    Icon(
-                        painter = icon,
-                        contentDescription = null
-                    )
-
-                }
-            )
-
-            BottomBarItem(
-                onClick = remember {
-                    {
-                        onUIAction(
-                            DrawScreenUIAction.SetDialogEditType(
-                                DialogEditType.COLOR
-                            )
-                        )
-                    }
-                },
-                label = {
-                    Text(text = stringResource(R.string.draw_screen_color_label))
-                },
-                icon = {
-
-                    val strokeColor = Theme.colors.onSurfaceElevationLow
-
-                    Canvas(
-                        modifier = Modifier
-                            .size(22.dp)
-                    ) {
-
-                        drawCircle(
-                            color = state.drawConfiguration.color,
-                            radius = 4.dp.toPx(),
-                            center = center
-                        )
-
-                        drawCircle(
-                            color = strokeColor,
-                            radius = 8.dp.toPx(),
-                            style = Stroke(
-                                width = 2.dp.toPx(),
-                                cap = StrokeCap.Round
-                            ),
-                            center = center
-                        )
-
-                    }
-
-                }
-            )
-
-            BottomBarItem(
-                onClick = remember {
-                    {
-                        onUIAction(
-                            DrawScreenUIAction.SetDialogEditType(
-                                DialogEditType.BG_LAYER
-                            )
-                        )
-                    }
-                },
-                label = {
-                    Text(text = stringResource(R.string.draw_screen_bg_layer_label))
-                },
-                icon = {
-
-                    Icon(
-                        painter = painterResource(R.drawable.bg_layer),
-                        contentDescription = null
-                    )
-
-                }
+            Icon(
+                painter = icon,
+                contentDescription = null
             )
 
         }
+    )
 
-    }
+    BottomBarItem(
+        onClick = remember {
+            {
+                onUIAction(
+                    DrawScreenUIAction.SetDialogEditType(
+                        DialogEditType.THICKNESS
+                    )
+                )
+            }
+        },
+        label = {
+            Text(text = stringResource(R.string.draw_screen_brush_width_label))
+        },
+        icon = {
+
+            val icon by rememberUpdatedState(
+                painterResource(
+                    when (state.drawConfiguration.thickness) {
+                        BrushThickness.THIN -> R.drawable.brush_thin
+                        BrushThickness.MEDIUM -> R.drawable.brush_medium
+                        BrushThickness.LARGE -> R.drawable.brush_medium
+                        BrushThickness.THICK -> R.drawable.brush_thick
+                    }
+                )
+            )
+
+            Icon(
+                painter = icon,
+                contentDescription = null
+            )
+
+        }
+    )
+
+    BottomBarItem(
+        onClick = remember {
+            {
+                onUIAction(
+                    DrawScreenUIAction.SetDialogEditType(
+                        DialogEditType.COLOR
+                    )
+                )
+            }
+        },
+        label = {
+            Text(text = stringResource(R.string.draw_screen_color_label))
+        },
+        icon = {
+
+            val strokeColor = Theme.colors.onSurfaceElevationLow
+
+            Canvas(
+                modifier = Modifier
+                    .size(22.dp)
+            ) {
+
+                drawCircle(
+                    color = state.drawConfiguration.color,
+                    radius = 4.dp.toPx(),
+                    center = center
+                )
+
+                drawCircle(
+                    color = strokeColor,
+                    radius = 8.dp.toPx(),
+                    style = Stroke(
+                        width = 2.dp.toPx(),
+                        cap = StrokeCap.Round
+                    ),
+                    center = center
+                )
+
+            }
+
+        }
+    )
+
+    BottomBarItem(
+        onClick = remember {
+            {
+                onUIAction(
+                    DrawScreenUIAction.SetDialogEditType(
+                        DialogEditType.BG_LAYER
+                    )
+                )
+            }
+        },
+        label = {
+            Text(text = stringResource(R.string.draw_screen_bg_layer_label))
+        },
+        icon = {
+
+            Icon(
+                painter = painterResource(R.drawable.bg_layer),
+                contentDescription = null
+            )
+
+        }
+    )
 
 }

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/main/draw_screen/DrawScreenTopBar.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/main/draw_screen/DrawScreenTopBar.kt
@@ -40,76 +40,67 @@ import com.stoyanvuchev.magicmessage.R
 import com.stoyanvuchev.magicmessage.core.ui.DrawingController
 import com.stoyanvuchev.magicmessage.core.ui.components.AuraButton
 import com.stoyanvuchev.magicmessage.core.ui.components.top_bar.TopBar
-import com.stoyanvuchev.magicmessage.core.ui.effect.defaultHazeEffect
 import com.stoyanvuchev.magicmessage.core.ui.event.NavigationEvent
-import dev.chrisbanes.haze.HazeState
 
 @Composable
 fun DrawScreenTopBar(
     state: DrawScreenState,
-    hazeState: HazeState,
     drawingController: DrawingController,
     onUIAction: (DrawScreenUIAction) -> Unit,
     onNavigationEvent: (NavigationEvent) -> Unit
-) {
+) = TopBar(
+    title = { Text(text = stringResource(R.string.app_name)) },
+    navigationAction = {
 
-    TopBar(
-        modifier = Modifier.defaultHazeEffect(hazeState = hazeState),
-        title = { Text(text = stringResource(R.string.app_name)) },
-        navigationAction = {
+        IconButton(
+            onClick = remember { { onNavigationEvent(NavigationEvent.NavigateUp) } }
+        ) {
+            Icon(
+                modifier = Modifier.size(28.dp),
+                painter = painterResource(R.drawable.arrow_left_outlined),
+                contentDescription = stringResource(R.string.navigate_back)
+            )
+        }
 
-            IconButton(
-                onClick = remember { { onNavigationEvent(NavigationEvent.NavigateUp) } }
-            ) {
-                Icon(
-                    modifier = Modifier.size(28.dp),
-                    painter = painterResource(R.drawable.arrow_left_outlined),
-                    contentDescription = null
-                )
-            }
+    },
+    actions = {
 
-        },
-        actions = {
+        IconButton(
+            onClick = remember { { onUIAction(DrawScreenUIAction.Undo) } },
+        ) {
+            Icon(
+                painter = painterResource(R.drawable.undo),
+                contentDescription = stringResource(R.string.action_undo)
+            )
+        }
 
-            IconButton(
-                onClick = remember { { onUIAction(DrawScreenUIAction.Undo) } },
-            ) {
-                Icon(
-                    painter = painterResource(R.drawable.undo),
-                    contentDescription = null
-                )
-            }
+        IconButton(
+            onClick = remember { { onUIAction(DrawScreenUIAction.Redo) } }
+        ) {
+            Icon(
+                painter = painterResource(R.drawable.redo),
+                contentDescription = stringResource(R.string.action_redo)
+            )
+        }
 
-            IconButton(
-                onClick = remember { { onUIAction(DrawScreenUIAction.Redo) } }
-            ) {
-                Icon(
-                    painter = painterResource(R.drawable.redo),
-                    contentDescription = null
-                )
-            }
+        val isGlowVisible by rememberUpdatedState(
+            drawingController.totalPointCount
+                    == DrawingController.MAX_POINTS
+        )
 
-            val isGlowVisible by rememberUpdatedState(
-                drawingController.totalPointCount
-                        == DrawingController.MAX_POINTS
+        AuraButton(
+            size = 40.dp,
+            onClick = { onUIAction(DrawScreenUIAction.Export(messageId = state.messageId)) },
+            isGlowVisible = isGlowVisible,
+            glowColor = state.drawConfiguration.color
+        ) {
+
+            Icon(
+                painter = painterResource(R.drawable.export),
+                contentDescription = stringResource(R.string.export_gif)
             )
 
-            AuraButton(
-                size = 40.dp,
-                onClick = { onUIAction(DrawScreenUIAction.Export(messageId = state.messageId)) },
-                hazeState = hazeState,
-                isGlowVisible = isGlowVisible,
-                glowColor = state.drawConfiguration.color
-            ) {
-
-                Icon(
-                    painter = painterResource(R.drawable.export),
-                    contentDescription = null
-                )
-
-            }
-
         }
-    )
 
-}
+    }
+)

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/main/draw_screen/DrawingCanvas.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/main/draw_screen/DrawingCanvas.kt
@@ -25,20 +25,25 @@
 package com.stoyanvuchev.magicmessage.presentation.main.draw_screen
 
 import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.border
 import androidx.compose.foundation.gestures.awaitEachGesture
 import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.gestures.drag
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.compositeOver
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.dp
 import com.stoyanvuchev.magicmessage.core.ui.DrawingController
 import com.stoyanvuchev.magicmessage.core.ui.ParticleUpdater
 import com.stoyanvuchev.magicmessage.core.ui.ext.drawStroke
+import com.stoyanvuchev.magicmessage.core.ui.theme.Theme
 import com.stoyanvuchev.magicmessage.domain.layer.BackgroundLayer
 import com.stoyanvuchev.magicmessage.domain.model.DrawConfiguration
 import com.stoyanvuchev.magicmessage.domain.model.StrokeModel
@@ -60,6 +65,13 @@ fun DrawingCanvas(
     Canvas(
         modifier = modifier
             .onGloballyPositioned { onSizeChanged(it.size) }
+            .border(
+                width = 1.dp,
+                color = Theme.colors.outline
+                    .compositeOver(Theme.colors.surfaceElevationLow),
+                shape = Theme.shapes.smallShape
+            )
+            .clip(shape = Theme.shapes.smallShape)
             .clipToBounds()
             .pointerInput(drawConfiguration) {
                 if (!controller.drawingEnabled) return@pointerInput

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/main/draw_screen/dialog/DrawScreenDialog.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/main/draw_screen/dialog/DrawScreenDialog.kt
@@ -57,10 +57,9 @@ import com.stoyanvuchev.magicmessage.core.ui.effect.defaultHazeEffect
 import com.stoyanvuchev.magicmessage.core.ui.theme.Theme
 import com.stoyanvuchev.magicmessage.domain.brush.BrushEffect
 import com.stoyanvuchev.magicmessage.domain.brush.BrushThickness
+import com.stoyanvuchev.magicmessage.domain.defaultDrawColors
 import com.stoyanvuchev.magicmessage.presentation.main.draw_screen.DrawScreenState
 import com.stoyanvuchev.magicmessage.presentation.main.draw_screen.DrawScreenUIAction
-import com.stoyanvuchev.magicmessage.domain.defaultDrawColors
-import dev.chrisbanes.haze.HazeState
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -69,7 +68,6 @@ fun DrawScreenDialog(
     type: DialogEditType,
     state: DrawScreenState,
     sheetState: SheetState,
-    hazeState: HazeState,
     onUIAction: (DrawScreenUIAction) -> Unit,
 ) {
 
@@ -99,7 +97,7 @@ fun DrawScreenDialog(
                         color = Theme.colors.outline,
                         shape = Theme.shapes.mediumShape
                     )
-                    .defaultHazeEffect(hazeState = hazeState)
+                    .defaultHazeEffect()
                     .background(color = Theme.colors.surfaceElevationHigh.copy(.25f))
                     .padding(8.dp)
             ) {

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/main/favorite_screen/FavoriteScreen.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/main/favorite_screen/FavoriteScreen.kt
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-package com.stoyanvuchev.magicmessage.presentation.main.home_screen
+package com.stoyanvuchev.magicmessage.presentation.main.favorite_screen
 
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedVisibility
@@ -41,7 +41,6 @@ import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.grid.rememberLazyGridState
-import androidx.compose.material3.FabPosition
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Scaffold
@@ -58,7 +57,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import com.stoyanvuchev.magicmessage.R
-import com.stoyanvuchev.magicmessage.core.ui.components.AuraButton
 import com.stoyanvuchev.magicmessage.core.ui.components.bottom_nav_bar.BottomNavBarTokens.NavigationBarHeight
 import com.stoyanvuchev.magicmessage.core.ui.components.grid.GridCreationItemDetailsLayout
 import com.stoyanvuchev.magicmessage.core.ui.components.grid.GridOfCreationItems
@@ -74,9 +72,9 @@ import com.stoyanvuchev.magicmessage.presentation.main.MainScreen
 
 @OptIn(ExperimentalSharedTransitionApi::class)
 @Composable
-fun HomeScreen(
-    state: HomeScreenState,
-    onUIAction: (HomeScreenUIAction) -> Unit,
+fun FavoriteScreen(
+    state: FavoriteScreenState,
+    onUIAction: (FavoriteScreenUIAction) -> Unit,
     onNavigationEvent: (NavigationEvent) -> Unit
 ) {
 
@@ -93,7 +91,7 @@ fun HomeScreen(
         topBar = {
 
             TopBar(
-                title = { Text(text = stringResource(R.string.home_screen_label)) },
+                title = { Text(text = stringResource(R.string.favorite_screen_label)) },
                 actions = {
 
                     AnimatedVisibility(
@@ -118,36 +116,6 @@ fun HomeScreen(
 
                 }
             )
-
-        },
-        floatingActionButtonPosition = FabPosition.Center,
-        floatingActionButton = {
-
-            if (sharedCreation == null) {
-
-                AuraButton(
-                    onClick = remember {
-                        {
-                            onNavigationEvent(
-                                NavigationEvent.NavigateTo(
-                                    MainScreen.Draw(null)
-                                )
-                            )
-                        }
-                    },
-                    isGlowVisible = true,
-                    size = 56.dp
-                ) {
-
-                    Icon(
-                        modifier = Modifier.size(24.dp),
-                        painter = painterResource(R.drawable.pencil_icon),
-                        contentDescription = null
-                    )
-
-                }
-
-            }
 
         },
         bottomBar = {
@@ -178,13 +146,13 @@ fun HomeScreen(
             ) {
 
                 Icon(
-                    modifier = Modifier.size(100.dp),
-                    painter = painterResource(R.drawable.logo_icon),
+                    modifier = Modifier.size(80.dp),
+                    painter = painterResource(R.drawable.favorite_outlined),
                     contentDescription = null
                 )
 
                 Text(
-                    text = stringResource(R.string.home_screen_empty_text),
+                    text = stringResource(R.string.favorite_screen_empty_text),
                     style = Theme.typefaces.bodyLarge,
                     color = Theme.colors.onSurfaceElevationLow.copy(.5f)
                 )
@@ -200,16 +168,16 @@ fun HomeScreen(
             GridOfCreationItems(
                 lazyGridState = lazyGridState,
                 innerPadding = innerPadding,
-                hazeSourceKey = "home_screen_grid_key"
+                hazeSourceKey = "favorite_screen_grid_key"
             ) {
 
-                if (state.exportedCreationsList.isNotEmpty()) {
+                if (state.draftedCreationsList.isNotEmpty()) {
 
                     gridOfCreationItemsSection(
                         sharedTransitionScope = this@SharedTransitionLayout,
                         label = UIString.Resource(resId = R.string.drafts_label),
                         items = state.draftedCreationsList,
-                        categoryKey = "home_drafted_items",
+                        categoryKey = "favorite_drafted_items",
                         sharedCreation = sharedCreation,
                         boundsTransform = boundsTransform,
                         onCreationClick = { creation ->
@@ -233,7 +201,7 @@ fun HomeScreen(
                         sharedTransitionScope = this@SharedTransitionLayout,
                         label = UIString.Resource(resId = R.string.exported_label),
                         items = state.exportedCreationsList,
-                        categoryKey = "home_exported_items",
+                        categoryKey = "favorite_exported_items",
                         sharedCreation = sharedCreation,
                         boundsTransform = boundsTransform,
                         onCreationClick = { creation ->
@@ -277,12 +245,12 @@ fun HomeScreen(
                         onClick = remember {
                             {
                                 sharedCreation?.let {
-                                    onUIAction(HomeScreenUIAction.ExportGif(it))
+                                    onUIAction(FavoriteScreenUIAction.ExportGif(it))
                                     sharedCreation = null
                                 }
                             }
                         },
-                        label = { Text(text = "Export GIF") },
+                        label = { Text(text = stringResource(R.string.export_gif)) },
                         icon = {
 
                             Icon(
@@ -309,10 +277,10 @@ fun HomeScreen(
                             onUIAction(
                                 if (!isFavorite) {
                                     isFavorite = true
-                                    HomeScreenUIAction.AddToFavorite(sharedCreation?.id)
+                                    FavoriteScreenUIAction.AddToFavorite(sharedCreation?.id)
                                 } else {
                                     isFavorite = false
-                                    HomeScreenUIAction.RemoveFromFavorite(sharedCreation?.id)
+                                    FavoriteScreenUIAction.RemoveFromFavorite(sharedCreation?.id)
                                 }
                             )
                         }

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/main/favorite_screen/FavoriteScreenState.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/main/favorite_screen/FavoriteScreenState.kt
@@ -22,19 +22,13 @@
  * SOFTWARE.
  */
 
-package com.stoyanvuchev.magicmessage.domain.model
+package com.stoyanvuchev.magicmessage.presentation.main.favorite_screen
 
 import androidx.compose.runtime.Stable
-import androidx.compose.ui.graphics.Color
-import com.stoyanvuchev.magicmessage.domain.brush.BrushEffect
-import com.stoyanvuchev.magicmessage.domain.serializer.ColorSerializer
-import kotlinx.serialization.Serializable
+import com.stoyanvuchev.magicmessage.domain.model.CreationModel
 
-@Serializable
 @Stable
-data class StrokeModel(
-    val points: List<TimedPoint>,
-    @Serializable(with = ColorSerializer::class) val color: Color,
-    val width: Float,
-    val effect: BrushEffect = BrushEffect.NONE
+class FavoriteScreenState(
+    val draftedCreationsList: List<CreationModel> = emptyList(),
+    val exportedCreationsList: List<CreationModel> = emptyList()
 )

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/main/favorite_screen/FavoriteScreenUIAction.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/main/favorite_screen/FavoriteScreenUIAction.kt
@@ -22,19 +22,24 @@
  * SOFTWARE.
  */
 
-package com.stoyanvuchev.magicmessage.domain.model
+package com.stoyanvuchev.magicmessage.presentation.main.favorite_screen
 
 import androidx.compose.runtime.Stable
-import androidx.compose.ui.graphics.Color
-import com.stoyanvuchev.magicmessage.domain.brush.BrushEffect
-import com.stoyanvuchev.magicmessage.domain.serializer.ColorSerializer
-import kotlinx.serialization.Serializable
+import com.stoyanvuchev.magicmessage.domain.model.CreationModel
 
-@Serializable
 @Stable
-data class StrokeModel(
-    val points: List<TimedPoint>,
-    @Serializable(with = ColorSerializer::class) val color: Color,
-    val width: Float,
-    val effect: BrushEffect = BrushEffect.NONE
-)
+interface FavoriteScreenUIAction {
+
+    data class RemoveFromFavorite(
+        val creationId: Long?
+    ) : FavoriteScreenUIAction
+
+    data class AddToFavorite(
+        val creationId: Long?
+    ) : FavoriteScreenUIAction
+
+    data class ExportGif(
+        val creation: CreationModel
+    ) : FavoriteScreenUIAction
+
+}

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/main/favorite_screen/FavoriteScreenViewModel.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/main/favorite_screen/FavoriteScreenViewModel.kt
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-package com.stoyanvuchev.magicmessage.presentation.main.home_screen
+package com.stoyanvuchev.magicmessage.presentation.main.favorite_screen
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -42,41 +42,41 @@ import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
 @HiltViewModel
-class HomeScreenViewModel @Inject constructor(
+class FavoriteScreenViewModel @Inject constructor(
     private val useCases: CreationUseCases
 ) : ViewModel() {
 
-    val state: StateFlow<HomeScreenState> = combine(
-        flow = useCases.getExportedUseCase(onlyFavorite = false),
-        flow2 = useCases.getDraftsUseCase(onlyFavorite = false)
+    val state: StateFlow<FavoriteScreenState> = combine(
+        flow = useCases.getExportedUseCase(onlyFavorite = true),
+        flow2 = useCases.getDraftsUseCase(onlyFavorite = true)
     ) { exported, drafted ->
 
-        HomeScreenState(
-            exportedCreationsList = exported,
-            draftedCreationsList = drafted
+        FavoriteScreenState(
+            draftedCreationsList = drafted,
+            exportedCreationsList = exported
         )
 
     }.stateIn(
         scope = viewModelScope,
         started = SharingStarted.WhileSubscribed(5_000),
-        initialValue = HomeScreenState()
+        initialValue = FavoriteScreenState()
     )
 
-    private val _uiActionChannel = Channel<HomeScreenUIAction>()
+    private val _uiActionChannel = Channel<FavoriteScreenUIAction>()
     val uiActionFlow = _uiActionChannel.receiveAsFlow()
 
     private val _navigationChannel = Channel<NavigationEvent>()
     val navigationFlow = _navigationChannel.receiveAsFlow()
 
-    fun onUIAction(action: HomeScreenUIAction) {
+    fun onUIAction(action: FavoriteScreenUIAction) {
         when (action) {
-            is HomeScreenUIAction.RemoveFromFavorite -> removeFromFavorite(action)
-            is HomeScreenUIAction.AddToFavorite -> addToFavorite(action)
-            is HomeScreenUIAction.ExportGif -> exportGif(action)
+            is FavoriteScreenUIAction.RemoveFromFavorite -> removeFromFavorite(action)
+            is FavoriteScreenUIAction.AddToFavorite -> addToFavorite(action)
+            is FavoriteScreenUIAction.ExportGif -> exportGif(action)
         }
     }
 
-    private fun removeFromFavorite(action: HomeScreenUIAction.RemoveFromFavorite) {
+    private fun removeFromFavorite(action: FavoriteScreenUIAction.RemoveFromFavorite) {
         viewModelScope.launch {
             withContext(Dispatchers.IO) {
                 useCases.removeAsFavoriteUseCase(action.creationId)
@@ -84,7 +84,7 @@ class HomeScreenViewModel @Inject constructor(
         }
     }
 
-    private fun addToFavorite(action: HomeScreenUIAction.AddToFavorite) {
+    private fun addToFavorite(action: FavoriteScreenUIAction.AddToFavorite) {
         viewModelScope.launch {
             withContext(Dispatchers.IO) {
                 useCases.markAsFavoriteUseCase(action.creationId)
@@ -92,7 +92,7 @@ class HomeScreenViewModel @Inject constructor(
         }
     }
 
-    private fun exportGif(action: HomeScreenUIAction.ExportGif) {
+    private fun exportGif(action: FavoriteScreenUIAction.ExportGif) {
         ExportDataHolder.strokes = action.creation.drawingSnapshot.strokes
         ExportDataHolder.bgLayer = action.creation.drawConfiguration.bgLayer
         sendUIAction(action)
@@ -102,7 +102,7 @@ class HomeScreenViewModel @Inject constructor(
         sendNavigationEvent(event)
     }
 
-    private fun sendUIAction(action: HomeScreenUIAction) {
+    private fun sendUIAction(action: FavoriteScreenUIAction) {
         viewModelScope.launch { _uiActionChannel.send(action) }
     }
 

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/main/home_screen/HomeScreenUIAction.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/main/home_screen/HomeScreenUIAction.kt
@@ -24,13 +24,19 @@
 
 package com.stoyanvuchev.magicmessage.presentation.main.home_screen
 
-import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.Stable
 import com.stoyanvuchev.magicmessage.domain.model.CreationModel
 
-@Immutable
+@Stable
 interface HomeScreenUIAction {
 
-    data object NewMessage : HomeScreenUIAction
+    data class RemoveFromFavorite(
+        val creationId: Long?
+    ) : HomeScreenUIAction
+
+    data class AddToFavorite(
+        val creationId: Long?
+    ) : HomeScreenUIAction
 
     data class ExportGif(
         val creation: CreationModel

--- a/app/src/main/res/drawable/close_outlined.xml
+++ b/app/src/main/res/drawable/close_outlined.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M5.636,5.636C5.929,5.343 6.404,5.343 6.697,5.636L12,10.939L17.303,5.636C17.596,5.343 18.071,5.343 18.364,5.636C18.657,5.929 18.657,6.404 18.364,6.697L13.061,12L18.364,17.303C18.657,17.596 18.657,18.071 18.364,18.364C18.071,18.657 17.596,18.657 17.303,18.364L12,13.061L6.697,18.364C6.404,18.657 5.929,18.657 5.636,18.364C5.343,18.071 5.343,17.596 5.636,17.303L10.939,12L5.636,6.697C5.343,6.404 5.343,5.929 5.636,5.636Z"
+      android:fillColor="#646464"
+      android:fillType="evenOdd"/>
+</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -34,7 +34,16 @@
     <string name="exporter_label_completed_description">"Enjoy the GIF 🎉"</string>
     <string name="exporter_label_view">View</string>
     <string name="exporter_label_cancel">Cancel</string>
-    <string name="home_screen_exported_label">Exported</string>
-    <string name="home_screen_drafted_label">Drafts</string>
+    <string name="exported_label">Exported</string>
+    <string name="drafts_label">Drafts</string>
     <string name="home_screen_empty_text">Tap the pen icon\nto draw something.</string>
+    <string name="favorite_screen_empty_text">Add some favorites\nfrom the home screen.</string>
+    <string name="dismiss_item_details">Dismiss item details.</string>
+    <string name="add_to_favorite">Add to Favorite</string>
+    <string name="remove_from_favorite">Remove from Favorite</string>
+    <string name="move_to_trash">Move to Trash</string>
+    <string name="export_gif">Export GIF</string>
+    <string name="navigate_back">Navigate back</string>
+    <string name="action_undo">Undo action</string>
+    <string name="action_redo">Redo action</string>
 </resources>


### PR DESCRIPTION
This commit introduces several UI enhancements, refactors existing components, and implements a new "Favorite" screen.

**Key Changes:**

- **Favorite Screen Implementation:**
    - Added `FavoriteScreen.kt` with a UI to display favorite drafted and exported creations.
    - Includes an empty state message when no favorites are present.
    - Utilizes `SharedTransitionLayout` for item animations and `GridCreationItemDetailsLayout` for viewing item details.
    - Added `FavoriteScreenViewModel.kt`, `FavoriteScreenState.kt`, and `FavoriteScreenUIAction.kt` for managing screen logic and state.
    - Integrated new use cases (`CreationMarkAsFavoriteUseCase`, `CreationRemoveAsFavoriteUseCase`) to handle favoriting/unfavoriting creations.
    - Added corresponding string resources for labels and actions.

- **UI Component Refactoring:**
    - **`GridCreationItemDetailsLayout`:** Renamed from `HomeScreenItemDetails` and moved to `core.ui.components.grid`. This component is now a generic layout for displaying creation item details with actions.
    - **`GridCreationItem`:** Renamed from `HomeScreenCreationItem` and moved to `core.ui.components.grid`. This component is now a generic item for displaying creations in a grid.
    - **`GridOfCreationItems` & `GridOfCreationItemsSection`:** New composables in `core.ui.components.grid` for building grids of creation items with section headers.
    - **Haze Effect Integration:**
        - Introduced `LocalHazeState` via `CompositionLocalProvider` in `UIWrapper.kt` to provide a global `HazeState`.
        - Removed explicit `hazeState` parameters from various composables (`DrawScreenTopBar`, `DrawScreenBottomBar`, `AuraButton`, `ListItemOption`, `ExportDialog`, `DrawScreenDialog`, `AppBottomNavBar`, `TopBar`, `BottomBar`) and made them use `LocalHazeState.current` by default. - `defaultHazeEffect` modifier now defaults to using `LocalHazeState.current`.
    - **`DrawingCanvas`:** Added a border and clip shape for better visual separation.
    - **`ListItemOption`:** Removed `hazeState` parameter.
    - **`TopBar` & `BottomBar`:** Now apply `defaultHazeEffect` internally.

- **Repository & DAO Enhancements:**
    - `CreationRepository` and `CreationDao` now support fetching drafts and finished creations filtered by favorite status.
    - Added `getAllExportedFavorite`, `getAllExported`, `getAllFavoriteDrafts`, and `getDrafts` methods to `CreationDao`.

- **String Resources:**
    - Added new string resources for the Favorite screen, item actions (Add/Remove from Favorite, Move to Trash, Export GIF), and accessibility descriptions (Navigate back, Undo, Redo, Dismiss item details).
    - Renamed some existing string resources (e.g., `home_screen_exported_label` to `exported_label`).

- **Other Changes:**
    - **`ExportGifServiceIntent`:** Created an object to encapsulate the logic for starting the `ExportGifService`.
    - **`DrawingController`:** Minor code formatting.
    - **`DefaultBGLayers`:** Changed `@Immutable` to `@Stable`.
    - **`BrushEffect` & `BrushThickness`:** Added `@Stable` annotation.
    - **`UIString`:** New sealed interface for representing strings that can be either basic text or string resources.
    - **`CANVAS_ASPECT_RATIO`:** New constant for canvas aspect ratio.
    - Added `close_outlined.xml` drawable.
    - Removed an unused `println` statement in `DrawingController`.
    - Removed `@Contextual` annotation from `StrokeModel` as it's not needed with `ColorSerializer`.
    - `HomeScreenUIAction`: Added `RemoveFromFavorite` and `AddToFavorite` actions. Removed `NewMessage`.
    - `AppNavHost`: Removed `ExperimentalSharedTransitionApi` and related unused parameters.

- **Dependency Injection:**
    - Updated `CreationModule` to provide `CreationMarkAsFavoriteUseCase` and `CreationRemoveAsFavoriteUseCase`.
    - Updated `CreationUseCases` to include the new favorite-related use cases.