### PR TITLE
Refactored Creation management, added Deleted screen functionality and UI/UX improvements.

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -4,7 +4,7 @@
     <selectionStates>
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
-        <DropdownSelection timestamp="2025-09-22T22:14:14.149063Z">
+        <DropdownSelection timestamp="2025-09-25T18:37:29.030659Z">
           <Target type="DEFAULT_BOOT">
             <handle>
               <DeviceId pluginId="LocalEmulator" identifier="path=/Users/stoyan/.android/avd/Pixel_6_Pro.avd" />

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         minSdk = 33
         targetSdk = 36
 
-        versionCode = 1
-        versionName = "0.1.0"
+        versionCode = 2
+        versionName = "0.1.1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/app/src/androidTest/java/com/stoyanvuchev/magicmessage/data/local/CreationDatabaseTest.kt
+++ b/app/src/androidTest/java/com/stoyanvuchev/magicmessage/data/local/CreationDatabaseTest.kt
@@ -153,7 +153,7 @@ class CreationDatabaseTest {
 
         dao.deleteAllDrafts()
 
-        val drafts = dao.getAllDrafts()
+        val drafts = dao.getAllDrafts(onlyFavorite = false, deleted = false)
         assertThat(drafts).isEqualTo(emptyList<CreationEntity>())
 
     }
@@ -175,7 +175,7 @@ class CreationDatabaseTest {
 
         dao.deleteAllCreations()
 
-        val drafts = dao.getAll()
+        val drafts = dao.getAll(onlyFavorite = false, deleted = false)
         assertThat(drafts).isEqualTo(emptyList<CreationEntity>())
 
     }

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/core/ui/components/RowSelectionItem.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/core/ui/components/RowSelectionItem.kt
@@ -41,12 +41,12 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.dp
 import com.stoyanvuchev.magicmessage.core.ui.components.bottom_bar.BottomBarTokens.BottomBarHeight
 import com.stoyanvuchev.magicmessage.core.ui.components.interaction.rememberRipple
 import com.stoyanvuchev.magicmessage.core.ui.theme.Theme
-import com.stoyanvuchev.magicmessage.core.ui.theme.isInDarkThemeMode
 
 @Composable
 fun RowScope.RowSelectionItem(
@@ -59,13 +59,13 @@ fun RowScope.RowSelectionItem(
 
     val bgColor by animateColorAsState(
         targetValue = Theme.colors.surfaceElevationHigh.copy(
-            alpha = if (selected) .75f else 0f
+            alpha = if (selected) .9f else 0f
         )
     )
 
     val borderColor by animateColorAsState(
         targetValue = Theme.colors.outline.copy(
-            alpha = if (selected) (if (isInDarkThemeMode()) .04f else 1f) else 0f
+            alpha = if (selected) .08f else 0f
         )
     )
 
@@ -78,15 +78,13 @@ fun RowScope.RowSelectionItem(
                 role = Role.Tab
             )
             .defaultMinSize(minHeight = BottomBarHeight)
+            .clip(shape = Theme.shapes.smallShape)
             .border(
                 width = 1.dp,
                 color = borderColor,
                 shape = Theme.shapes.smallShape
             )
-            .background(
-                color = bgColor,
-                shape = Theme.shapes.smallShape
-            )
+            .background(color = bgColor)
             .weight(1f),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.spacedBy(8.dp, Alignment.CenterVertically)

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/core/ui/components/grid/GridCreationItem.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/core/ui/components/grid/GridCreationItem.kt
@@ -57,7 +57,7 @@ import com.stoyanvuchev.magicmessage.domain.model.CreationModel
 fun GridCreationItem(
     modifier: Modifier = Modifier,
     creation: CreationModel,
-    onCreationClick: (CreationModel) -> Unit,
+    onCreationClick: (CreationModel, IntSize) -> Unit,
     onCreationLongClick: (CreationModel, IntSize) -> Unit
 ) {
 
@@ -97,7 +97,7 @@ fun GridCreationItem(
             .clip(shape = Theme.shapes.smallShape)
             .clipToBounds()
             .combinedClickable(
-                onClick = remember { { onCreationClick(creation) } },
+                onClick = remember { { onCreationClick(creation, canvasSize) } },
                 onLongClick = remember { { onCreationLongClick(creation, canvasSize) } },
                 interactionSource = remember { MutableInteractionSource() },
                 indication = rememberRipple(),

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/core/ui/components/grid/GridCreationItemDetailsLayout.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/core/ui/components/grid/GridCreationItemDetailsLayout.kt
@@ -1,19 +1,43 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2025 Stoyan Vuchev
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES, OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package com.stoyanvuchev.magicmessage.core.ui.components.grid
 
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.ExperimentalSharedTransitionApi
 import androidx.compose.animation.SharedTransitionScope
-import androidx.compose.animation.core.SpringSpec
+import androidx.compose.animation.animateContentSize
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.togetherWith
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -21,20 +45,27 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
+import com.stoyanvuchev.magicmessage.R
 import com.stoyanvuchev.magicmessage.core.ui.components.bottom_nav_bar.BottomNavBarTokens.NavigationBarHeight
-import com.stoyanvuchev.magicmessage.core.ui.effect.defaultHazeEffect
+import com.stoyanvuchev.magicmessage.core.ui.components.list.ListOptionItem
+import com.stoyanvuchev.magicmessage.core.ui.theme.Theme
 import com.stoyanvuchev.magicmessage.domain.model.CreationModel
 
 @OptIn(ExperimentalSharedTransitionApi::class)
@@ -42,29 +73,38 @@ import com.stoyanvuchev.magicmessage.domain.model.CreationModel
 fun SharedTransitionScope.GridCreationItemDetailsLayout(
     creation: CreationModel?,
     innerPadding: PaddingValues,
-    boundsTransform: (Rect, Rect) -> SpringSpec<Rect>,
     canvasSize: IntSize,
     onDismiss: () -> Unit,
-    onCreationClick: (CreationModel) -> Unit,
-    actions: @Composable ColumnScope.() -> Unit
+    onCreationClick: (CreationModel, IntSize) -> Unit,
+    onExportGif: (CreationModel) -> Unit,
+    onMarkAsFavorite: (Long) -> Unit,
+    onRemoveAsFavorite: (Long) -> Unit,
+    onMoveToTrash: (Long) -> Unit
 ) {
 
     val isBackgroundVisible by rememberUpdatedState(creation != null)
+    val topPadding by remember {
+        derivedStateOf { innerPadding.calculateTopPadding() }
+    }
 
     AnimatedVisibility(
         modifier = Modifier.fillMaxSize(),
         visible = isBackgroundVisible,
-        enter = fadeIn(),
-        exit = fadeOut()
+        enter = remember { fadeIn() },
+        exit = remember { fadeOut() }
     ) {
 
         Box(
             modifier = Modifier
                 .fillMaxSize()
                 .navigationBarsPadding()
-                .padding(bottom = NavigationBarHeight)
-                .defaultHazeEffect()
-                .padding(top = innerPadding.calculateTopPadding())
+                .padding(
+                    top = topPadding,
+                    bottom = NavigationBarHeight
+                )
+                .background(
+                    color = Theme.colors.surfaceElevationLow.copy(.75f)
+                )
         )
 
     }
@@ -84,7 +124,7 @@ fun SharedTransitionScope.GridCreationItemDetailsLayout(
                 modifier = Modifier
                     .fillMaxSize()
                     .navigationBarsPadding()
-                    .padding(top = innerPadding.calculateTopPadding())
+                    .padding(top = topPadding)
                     .clickable(
                         onClick = onDismiss,
                         indication = null,
@@ -108,14 +148,13 @@ fun SharedTransitionScope.GridCreationItemDetailsLayout(
 
                 GridCreationItem(
                     modifier = Modifier
-                        .size(dpSize)
                         .sharedElement(
                             sharedContentState = rememberSharedContentState(
                                 key = sharedCreation.id ?: 0
                             ),
-                            animatedVisibilityScope = this@AnimatedContent,
-                            boundsTransform = boundsTransform,
-                        ),
+                            animatedVisibilityScope = this@AnimatedContent
+                        )
+                        .size(dpSize),
                     creation = sharedCreation,
                     onCreationClick = onCreationClick,
                     onCreationLongClick = remember { { _, _ -> } }
@@ -129,12 +168,95 @@ fun SharedTransitionScope.GridCreationItemDetailsLayout(
                             sharedContentState = rememberSharedContentState(
                                 key = "${sharedCreation.id ?: 0}-bounds"
                             ),
-                            animatedVisibilityScope = this@AnimatedContent,
-                            boundsTransform = boundsTransform,
+                            animatedVisibilityScope = this@AnimatedContent
                         )
+                        .padding(horizontal = 32.dp)
                 ) {
 
-                    actions()
+                    if (sharedCreation.isDraft) {
+
+                        ListOptionItem(
+                            onClick = remember { { onExportGif(sharedCreation); onDismiss() } },
+                            label = { Text(text = stringResource(R.string.export_gif)) },
+                            icon = {
+
+                                Icon(
+                                    modifier = Modifier.size(24.dp),
+                                    painter = painterResource(R.drawable.export),
+                                    contentDescription = null
+                                )
+
+                            }
+                        )
+
+                        Spacer(modifier = Modifier.height(8.dp))
+
+                    }
+
+                    var isFavorite by remember { mutableStateOf(sharedCreation.isFavorite) }
+
+                    val favoritePainter by rememberUpdatedState(
+                        painterResource(
+                            if (isFavorite) R.drawable.favorite_filled
+                            else R.drawable.favorite_outlined
+                        )
+                    )
+
+                    val favoriteTitle by rememberUpdatedState(
+                        stringResource(
+                            if (!isFavorite) R.string.add_to_favorite
+                            else R.string.remove_from_favorite
+                        )
+                    )
+
+                    val onIsFavoriteLambda = remember(isFavorite) {
+                        {
+                            if (!isFavorite) {
+                                isFavorite = true
+                                onMarkAsFavorite(sharedCreation.id!!)
+                            } else {
+                                isFavorite = false
+                                onRemoveAsFavorite(sharedCreation.id!!)
+                            }
+                        }
+                    }
+
+                    ListOptionItem(
+                        onClick = onIsFavoriteLambda,
+                        label = {
+
+                            Text(
+                                modifier = Modifier.animateContentSize(alignment = Alignment.Center),
+                                text = favoriteTitle
+                            )
+
+                        },
+                        icon = {
+
+                            Icon(
+                                modifier = Modifier.size(24.dp),
+                                painter = favoritePainter,
+                                contentDescription = null
+                            )
+
+                        }
+                    )
+
+                    Spacer(modifier = Modifier.height(8.dp))
+
+                    ListOptionItem(
+                        onClick = remember { { onMoveToTrash(creation?.id!!); onDismiss() } },
+                        label = { Text(text = stringResource(R.string.move_to_trash)) },
+                        icon = {
+
+                            Icon(
+                                modifier = Modifier.size(24.dp),
+                                painter = painterResource(R.drawable.delete),
+                                contentDescription = null
+                            )
+
+                        }
+                    )
 
                 }
 

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/core/ui/components/grid/GridDeletedCreationItemDetailsLayout.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/core/ui/components/grid/GridDeletedCreationItemDetailsLayout.kt
@@ -1,0 +1,354 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2025 Stoyan Vuchev
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES, OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.stoyanvuchev.magicmessage.core.ui.components.grid
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.ExperimentalSharedTransitionApi
+import androidx.compose.animation.SharedTransitionScope
+import androidx.compose.animation.animateContentSize
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.togetherWith
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.dp
+import com.stoyanvuchev.magicmessage.R
+import com.stoyanvuchev.magicmessage.core.ui.components.bottom_nav_bar.BottomNavBarTokens.NavigationBarHeight
+import com.stoyanvuchev.magicmessage.core.ui.components.list.ListOptionItem
+import com.stoyanvuchev.magicmessage.core.ui.effect.defaultHazeEffect
+import com.stoyanvuchev.magicmessage.core.ui.theme.Theme
+import com.stoyanvuchev.magicmessage.domain.model.CreationModel
+
+@OptIn(ExperimentalSharedTransitionApi::class)
+@Composable
+fun SharedTransitionScope.GridDeletedCreationItemDetailsLayout(
+    creation: CreationModel?,
+    innerPadding: PaddingValues,
+    canvasSize: IntSize,
+    onDismiss: () -> Unit,
+    onRestore: (Long) -> Unit,
+    onPermanentlyDelete: (Long) -> Unit
+) {
+
+    val isBackgroundVisible by rememberUpdatedState(creation != null)
+    val topPadding by remember {
+        derivedStateOf { innerPadding.calculateTopPadding() }
+    }
+
+    AnimatedVisibility(
+        modifier = Modifier.fillMaxSize(),
+        visible = isBackgroundVisible,
+        enter = remember { fadeIn() },
+        exit = remember { fadeOut() }
+    ) {
+
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .navigationBarsPadding()
+                .padding(
+                    top = topPadding,
+                    bottom = NavigationBarHeight
+                )
+                .background(
+                    color = Theme.colors.surfaceElevationLow.copy(.75f)
+                )
+        )
+
+    }
+
+    AnimatedContent(
+        modifier = Modifier
+            .padding(bottom = NavigationBarHeight)
+            .fillMaxSize(),
+        targetState = creation,
+        transitionSpec = remember { { fadeIn() togetherWith fadeOut() } },
+        label = "GridItemDetailsLayoutAnimatedContent"
+    ) { sharedCreation ->
+
+        if (sharedCreation != null) {
+
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .navigationBarsPadding()
+                    .padding(top = topPadding)
+                    .clickable(
+                        onClick = onDismiss,
+                        indication = null,
+                        interactionSource = remember { MutableInteractionSource() }
+                    ),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.Center
+            ) {
+
+                val density = LocalDensity.current
+                val dpSize by remember {
+                    derivedStateOf {
+                        with(density) {
+                            DpSize(
+                                width = canvasSize.width.toDp(),
+                                height = canvasSize.height.toDp()
+                            )
+                        }
+                    }
+                }
+
+                GridCreationItem(
+                    modifier = Modifier
+                        .sharedElement(
+                            sharedContentState = rememberSharedContentState(
+                                key = sharedCreation.id ?: 0
+                            ),
+                            animatedVisibilityScope = this@AnimatedContent
+                        )
+                        .size(dpSize),
+                    creation = sharedCreation,
+                    onCreationClick = remember { { _, _ -> } },
+                    onCreationLongClick = remember { { _, _ -> } }
+                )
+
+                Spacer(modifier = Modifier.height(64.dp))
+
+                Column(
+                    modifier = Modifier
+                        .sharedBounds(
+                            sharedContentState = rememberSharedContentState(
+                                key = "${sharedCreation.id ?: 0}-bounds"
+                            ),
+                            animatedVisibilityScope = this@AnimatedContent
+                        )
+                        .padding(horizontal = 32.dp)
+                        .animateContentSize()
+                ) {
+
+                    ListOptionItem(
+                        onClick = remember { { onRestore(creation?.id!!); onDismiss() } },
+                        label = { Text(text = stringResource(R.string.restore)) },
+                        icon = {
+
+                            Icon(
+                                modifier = Modifier.size(24.dp),
+                                painter = painterResource(R.drawable.undo),
+                                contentDescription = null
+                            )
+
+                        }
+                    )
+
+                    Spacer(modifier = Modifier.height(8.dp))
+
+                    var isWaringShown by remember { mutableStateOf(false) }
+
+                    BackHandler(enabled = isWaringShown) { isWaringShown = false }
+
+                    AnimatedVisibility(
+                        visible = !isWaringShown,
+                        enter = remember { fadeIn() },
+                        exit = remember { fadeOut() }
+                    ) {
+
+                        ListOptionItem(
+                            modifier = Modifier
+                                .sharedBounds(
+                                    sharedContentState = rememberSharedContentState(
+                                        key = "delete-item-bounds"
+                                    ),
+                                    animatedVisibilityScope = this@AnimatedVisibility
+                                ),
+                            onClick = remember { { isWaringShown = true } },
+                            label = { Text(text = stringResource(R.string.delete)) },
+                            icon = {
+
+                                Icon(
+                                    modifier = Modifier.size(24.dp),
+                                    painter = painterResource(R.drawable.delete),
+                                    contentDescription = null,
+                                    tint = Theme.colors.error
+                                )
+
+                            }
+                        )
+
+                    }
+
+                    AnimatedVisibility(
+                        visible = isWaringShown,
+                        enter = remember { fadeIn() },
+                        exit = remember { fadeOut() }
+                    ) {
+
+                        Column(
+                            modifier = Modifier
+                                .sharedBounds(
+                                    sharedContentState = rememberSharedContentState(
+                                        key = "delete-item-bounds"
+                                    ),
+                                    animatedVisibilityScope = this@AnimatedVisibility
+                                )
+                                .padding(horizontal = 24.dp)
+                                .fillMaxWidth()
+                                .clip(shape = Theme.shapes.smallShape)
+                                .defaultHazeEffect()
+                                .background(Theme.colors.surfaceElevationHigh.copy(.5f))
+                                .border(
+                                    width = 1.dp,
+                                    shape = Theme.shapes.smallShape,
+                                    color = Theme.colors.outline
+                                )
+                                .padding(16.dp),
+                            verticalArrangement = Arrangement.spacedBy(24.dp)
+                        ) {
+
+                            Row(
+                                modifier = Modifier.fillMaxWidth(),
+                                horizontalArrangement = Arrangement.spacedBy(16.dp),
+                                verticalAlignment = Alignment.CenterVertically
+                            ) {
+
+                                Icon(
+                                    modifier = Modifier.size(24.dp),
+                                    painter = painterResource(R.drawable.delete),
+                                    contentDescription = null,
+                                    tint = Theme.colors.error
+                                )
+
+                                Text(
+                                    text = stringResource(R.string.delete),
+                                    style = Theme.typefaces.bodyLarge
+                                )
+
+                            }
+
+                            Text(
+                                text = stringResource(R.string.delete_screen_confirm_delete_description),
+                                style = Theme.typefaces.bodyMedium
+                            )
+
+                            Row(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .offset(y = 3.dp),
+                                horizontalArrangement = Arrangement.spacedBy(
+                                    8.dp,
+                                    Alignment.End
+                                ),
+                                verticalAlignment = Alignment.Bottom
+                            ) {
+
+                                OutlinedButton(
+                                    onClick = remember { { isWaringShown = false } },
+                                    colors = ButtonDefaults.elevatedButtonColors(
+                                        containerColor = Theme.colors.surfaceElevationHigh,
+                                        contentColor = Theme.colors.onSurfaceElevationHigh
+                                    ),
+                                    shape = Theme.shapes.largeShape,
+                                    border = BorderStroke(
+                                        width = 1.dp,
+                                        color = Theme.colors.outline
+                                    )
+                                ) {
+
+                                    Text(
+                                        text = stringResource(R.string.delete_label_cancel),
+                                        style = Theme.typefaces.bodyLarge
+                                    )
+
+                                }
+
+                                OutlinedButton(
+                                    onClick = remember {
+                                        { onPermanentlyDelete(creation?.id!!); onDismiss() }
+                                    },
+                                    colors = ButtonDefaults.elevatedButtonColors(
+                                        containerColor = Theme.colors.error,
+                                        contentColor = Theme.colors.onError
+                                    ),
+                                    shape = Theme.shapes.largeShape,
+                                    border = BorderStroke(
+                                        width = 1.dp,
+                                        color = Theme.colors.outline
+                                    )
+                                ) {
+
+                                    Text(
+                                        text = stringResource(R.string.delete_label_permanently),
+                                        style = Theme.typefaces.bodyLarge
+                                    )
+
+                                }
+
+                            }
+
+                        }
+
+                    }
+
+                }
+
+            }
+
+        }
+
+    }
+
+}

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/core/ui/components/grid/GridOfCreationItems.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/core/ui/components/grid/GridOfCreationItems.kt
@@ -29,6 +29,7 @@ import androidx.compose.animation.SharedTransitionLayout
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.GridItemSpan
 import androidx.compose.foundation.lazy.grid.LazyGridScope
@@ -38,12 +39,14 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.stoyanvuchev.magicmessage.core.ui.components.EmptyBottomSpacer
+import com.stoyanvuchev.magicmessage.core.ui.effect.defaultLightWeightBlur
 import com.stoyanvuchev.magicmessage.core.ui.ext.LocalHazeState
 import dev.chrisbanes.haze.hazeSource
 
 @OptIn(ExperimentalSharedTransitionApi::class)
 @Composable
 fun GridOfCreationItems(
+    isLightWeightBlurApplied: Boolean,
     lazyGridState: LazyGridState,
     innerPadding: PaddingValues,
     hazeSourceKey: String,
@@ -56,7 +59,9 @@ fun GridOfCreationItems(
             .hazeSource(
                 state = LocalHazeState.current,
                 key = hazeSourceKey
-            ),
+            )
+            .defaultLightWeightBlur(isApplied = isLightWeightBlurApplied)
+            .padding(horizontal = 24.dp),
         contentPadding = innerPadding,
         state = lazyGridState,
         columns = GridCells.Fixed(2),

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/core/ui/components/list/ListOfOptionItems.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/core/ui/components/list/ListOfOptionItems.kt
@@ -36,12 +36,14 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.stoyanvuchev.magicmessage.core.ui.components.EmptyBottomSpacer
+import com.stoyanvuchev.magicmessage.core.ui.effect.defaultLightWeightBlur
 import com.stoyanvuchev.magicmessage.core.ui.ext.LocalHazeState
 import dev.chrisbanes.haze.hazeSource
 
 @OptIn(ExperimentalSharedTransitionApi::class)
 @Composable
 fun ListOfOptionItems(
+    isLightWeightBlueApplied: Boolean,
     lazyListState: LazyListState,
     innerPadding: PaddingValues,
     hazeSourceKey: String,
@@ -54,7 +56,8 @@ fun ListOfOptionItems(
             .hazeSource(
                 state = LocalHazeState.current,
                 key = hazeSourceKey
-            ),
+            )
+            .defaultLightWeightBlur(isApplied = isLightWeightBlueApplied),
         state = lazyListState,
         contentPadding = innerPadding,
         verticalArrangement = Arrangement.spacedBy(8.dp)

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/core/ui/components/list/ListOptionItemDetailsLayout.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/core/ui/components/list/ListOptionItemDetailsLayout.kt
@@ -53,6 +53,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
@@ -64,7 +65,6 @@ import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.stoyanvuchev.magicmessage.core.ui.components.bottom_nav_bar.BottomNavBarTokens.NavigationBarHeight
-import com.stoyanvuchev.magicmessage.core.ui.effect.defaultHazeEffect
 import com.stoyanvuchev.magicmessage.core.ui.theme.Theme
 
 @OptIn(ExperimentalSharedTransitionApi::class)
@@ -80,6 +80,9 @@ fun SharedTransitionScope.ListOptionItemDetailsLayout(
 ) {
 
     val isBackgroundVisible by rememberUpdatedState(sharedKey != null)
+    val topPadding by remember {
+        derivedStateOf { innerPadding.calculateTopPadding() }
+    }
 
     AnimatedVisibility(
         modifier = Modifier.fillMaxSize(),
@@ -92,9 +95,13 @@ fun SharedTransitionScope.ListOptionItemDetailsLayout(
             modifier = Modifier
                 .fillMaxSize()
                 .navigationBarsPadding()
-                .padding(bottom = NavigationBarHeight)
-                .defaultHazeEffect()
-                .padding(top = innerPadding.calculateTopPadding())
+                .padding(
+                    top = topPadding,
+                    bottom = NavigationBarHeight
+                )
+                .background(
+                    color = Theme.colors.surfaceElevationLow.copy(.5f)
+                )
         )
 
     }
@@ -114,7 +121,7 @@ fun SharedTransitionScope.ListOptionItemDetailsLayout(
                 modifier = Modifier
                     .fillMaxSize()
                     .navigationBarsPadding()
-                    .padding(top = innerPadding.calculateTopPadding())
+                    .padding(top = topPadding)
                     .clickable(
                         onClick = remember { { onSharedKey(null) } },
                         indication = null,

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/core/ui/effect/DefaultHazeEffect.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/core/ui/effect/DefaultHazeEffect.kt
@@ -26,6 +26,7 @@ package com.stoyanvuchev.magicmessage.core.ui.effect
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
 import androidx.compose.ui.unit.dp
 import com.stoyanvuchev.magicmessage.core.ui.ext.LocalHazeState
 import com.stoyanvuchev.magicmessage.core.ui.theme.Theme
@@ -38,14 +39,16 @@ import dev.chrisbanes.haze.hazeEffect
 fun Modifier.defaultHazeEffect(
     hazeState: HazeState = LocalHazeState.current
 ): Modifier {
-    return hazeEffect(
-        state = hazeState,
-        style = HazeStyle(
-            tint = HazeTint(color = Theme.colors.surfaceElevationLow.copy(.75f)),
-            blurRadius = 16.dp,
-            noiseFactor = -1f,
-            backgroundColor = Theme.colors.surfaceElevationLow
+    return composed {
+        hazeEffect(
+            state = hazeState,
+            style = HazeStyle(
+                tint = HazeTint(color = Theme.colors.surfaceElevationLow.copy(.75f)),
+                blurRadius = 16.dp,
+                noiseFactor = -1f,
+                backgroundColor = Theme.colors.surfaceElevationLow
 
+            )
         )
-    )
+    }
 }

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/core/ui/effect/DefaultLightweightBlur.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/core/ui/effect/DefaultLightweightBlur.kt
@@ -22,18 +22,31 @@
  * SOFTWARE.
  */
 
-package com.stoyanvuchev.magicmessage.domain.model
+package com.stoyanvuchev.magicmessage.core.ui.effect
 
-import androidx.compose.runtime.Stable
-import kotlinx.serialization.Serializable
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.animation.core.spring
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
+import androidx.compose.ui.draw.blur
+import androidx.compose.ui.unit.dp
 
-@Stable
-@Serializable
-data class CreationModel(
-    val id: Long?,
-    val createdAt: Long,
-    val isDraft: Boolean,
-    val isFavorite: Boolean,
-    @Stable val drawConfiguration: DrawConfiguration,
-    @Stable val drawingSnapshot: DrawingSnapshot
-)
+fun Modifier.defaultLightWeightBlur(
+    isApplied: Boolean
+): Modifier {
+    return composed {
+
+        val radius by animateDpAsState(
+            targetValue = if (isApplied) 16.dp else 0.dp,
+            animationSpec = spring(
+                dampingRatio = Spring.DampingRatioNoBouncy,
+                stiffness = Spring.StiffnessMediumLow
+            )
+        )
+
+        blur(radius = radius)
+
+    }
+}

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/core/ui/theme/color/ColorPaletteTokens.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/core/ui/theme/color/ColorPaletteTokens.kt
@@ -44,7 +44,7 @@ object LightColorPaletteTokens : ColorPaletteTokens {
     override val error: Color get() = Color(0xFFCA1F2D)
     override val onError: Color get() = Color(0xFFFFFFFF)
 
-    override val outline: Color get() = Color(0xFFC3D2DA)
+    override val outline: Color get() = Color(0x14000000)
 
 }
 
@@ -65,7 +65,7 @@ object DarkColorPaletteTokens : ColorPaletteTokens {
     override val error: Color get() = Color(0xFFCA1F2D)
     override val onError: Color get() = Color(0xFFFFFFFF)
 
-    override val outline: Color get() = Color(0x0AFFFFFF)
+    override val outline: Color get() = Color(0x14FFFFFF)
 
 }
 

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/core/ui/transition/DefaultBoundsTransformation.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/core/ui/transition/DefaultBoundsTransformation.kt
@@ -26,8 +26,10 @@ package com.stoyanvuchev.magicmessage.core.ui.transition
 
 import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.spring
+import androidx.compose.runtime.Stable
 import androidx.compose.ui.geometry.Rect
 
+@Stable
 val defaultBoundsTransformation = { _: Rect, _: Rect ->
     spring<Rect>(
         dampingRatio = Spring.DampingRatioNoBouncy,

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/core/ui/transition/DefaultTransitions.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/core/ui/transition/DefaultTransitions.kt
@@ -60,7 +60,7 @@ object DefaultTransitions {
             ) + scaleIn(
                 initialScale = initialScale,
                 animationSpec = spring(
-                    dampingRatio = Spring.DampingRatioNoBouncy,
+                    dampingRatio = Spring.DampingRatioLowBouncy,
                     stiffness = Spring.StiffnessMediumLow
                 )
             )
@@ -105,7 +105,7 @@ object DefaultTransitions {
             ) + scaleOut(
                 targetScale = targetScale,
                 animationSpec = spring(
-                    dampingRatio = Spring.DampingRatioNoBouncy,
+                    dampingRatio = Spring.DampingRatioLowBouncy,
                     stiffness = Spring.StiffnessMediumLow
                 )
             )

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/data/local/CreationDao.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/data/local/CreationDao.kt
@@ -52,29 +52,35 @@ interface CreationDao {
 
     // Exported
 
-    fun getAll(onlyFavorite: Boolean = false): Flow<List<CreationEntity>> {
-        return if (onlyFavorite) getAllExportedFavorite()
-        else getAllExported()
+    fun getAll(
+        onlyFavorite: Boolean,
+        deleted: Boolean
+    ): Flow<List<CreationEntity>> {
+        return if (onlyFavorite) getAllExportedFavorite(deleted)
+        else getAllExported(deleted)
     }
 
-    @Query("SELECT * FROM creations WHERE isDraft IS FALSE AND isFavorite IS TRUE ORDER BY createdAt DESC")
-    fun getAllExportedFavorite(): Flow<List<CreationEntity>>
+    @Query("SELECT * FROM creations WHERE isDeleted = :deleted AND isDraft IS FALSE AND isFavorite IS TRUE ORDER BY createdAt DESC")
+    fun getAllExportedFavorite(deleted: Boolean): Flow<List<CreationEntity>>
 
-    @Query("SELECT * FROM creations WHERE isDraft IS FALSE ORDER BY createdAt DESC")
-    fun getAllExported(): Flow<List<CreationEntity>>
+    @Query("SELECT * FROM creations WHERE isDeleted = :deleted AND isDraft IS FALSE ORDER BY createdAt DESC")
+    fun getAllExported(deleted: Boolean): Flow<List<CreationEntity>>
 
     // Drafts
 
-    fun getAllDrafts(onlyFavorite: Boolean = false): Flow<List<CreationEntity>> {
-        return if (onlyFavorite) getAllFavoriteDrafts()
-        else getDrafts()
+    fun getAllDrafts(
+        onlyFavorite: Boolean,
+        deleted: Boolean
+    ): Flow<List<CreationEntity>> {
+        return if (onlyFavorite) getAllFavoriteDrafts(deleted)
+        else getDrafts(deleted)
     }
 
-    @Query("SELECT * FROM creations WHERE isDraft IS TRUE ORDER BY createdAt DESC")
-    fun getDrafts(): Flow<List<CreationEntity>>
+    @Query("SELECT * FROM creations WHERE isDeleted = :deleted AND isDraft IS TRUE ORDER BY createdAt DESC")
+    fun getDrafts(deleted: Boolean): Flow<List<CreationEntity>>
 
-    @Query("SELECT * FROM creations WHERE isDraft IS TRUE AND isFavorite IS TRUE ORDER BY createdAt DESC")
-    fun getAllFavoriteDrafts(): Flow<List<CreationEntity>>
+    @Query("SELECT * FROM creations WHERE isDeleted = :deleted AND isDraft IS TRUE AND isFavorite IS TRUE ORDER BY createdAt DESC")
+    fun getAllFavoriteDrafts(deleted: Boolean): Flow<List<CreationEntity>>
 
     // By ID
 

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/data/local/CreationEntity.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/data/local/CreationEntity.kt
@@ -39,6 +39,7 @@ data class CreationEntity(
     val id: Long? = null,
 
     val createdAt: Long = 0L,
+    val isDeleted: Boolean = false,
     val isDraft: Boolean = true,
     val isFavorite: Boolean = false,
 

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/data/preferences/AppPreferencesImpl.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/data/preferences/AppPreferencesImpl.kt
@@ -32,7 +32,6 @@ import androidx.datastore.preferences.core.stringPreferencesKey
 import com.stoyanvuchev.magicmessage.core.ui.theme.ThemeMode
 import com.stoyanvuchev.magicmessage.domain.preferences.AppPreferences
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.serialization.json.Json
 import javax.inject.Inject
@@ -58,9 +57,12 @@ class AppPreferencesImpl @Inject constructor(
 
     // Theme Mode
 
-    override fun getThemeMode(): Flow<ThemeMode> = dataStore.data.map {
-        val json = it[THEME_MODE_KEY]
-        json?.let { mode -> Json.decodeFromString<ThemeMode?>(mode) } ?: ThemeMode.Dark
+    override fun getThemeMode(): Flow<ThemeMode> {
+        return dataStore.data.map {
+            it[THEME_MODE_KEY]?.let { mode ->
+                Json.decodeFromString<ThemeMode?>(mode)
+            } ?: ThemeMode.System
+        }
     }
 
     override suspend fun setThemeMode(themeMode: ThemeMode) {

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/data/repository/CreationRepositoryImpl.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/data/repository/CreationRepositoryImpl.kt
@@ -86,16 +86,34 @@ class CreationRepositoryImpl @Inject constructor(
         dao.update(creation.copy(isFavorite = false))
     }
 
-    override fun getDrafts(onlyFavorite: Boolean): Flow<List<CreationModel>> {
-        return dao.getAllDrafts(onlyFavorite).map { it.map { e -> e.toModel() } }
+    override fun getDrafts(
+        onlyFavorite: Boolean,
+        deleted: Boolean
+    ): Flow<List<CreationModel>> {
+        return dao.getAllDrafts(onlyFavorite, deleted)
+            .map { it.map { e -> e.toModel() } }
     }
 
-    override fun getFinished(onlyFavorite: Boolean): Flow<List<CreationModel>> {
-        return dao.getAll(onlyFavorite).map { it.map { e -> e.toModel() } }
+    override fun getFinished(
+        onlyFavorite: Boolean,
+        deleted: Boolean
+    ): Flow<List<CreationModel>> {
+        return dao.getAll(onlyFavorite, deleted)
+            .map { it.map { e -> e.toModel() } }
     }
 
     override suspend fun getById(id: Long): CreationModel? {
         return dao.getById(id)?.toModel()
+    }
+
+    override suspend fun moveCreationToTrash(creationId: Long) {
+        val creation = dao.getById(creationId) ?: return
+        dao.update(creation.copy(isDeleted = true))
+    }
+
+    override suspend fun restoreDeletedCreation(creationId: Long) {
+        val creation = dao.getById(creationId) ?: return
+        dao.update(creation.copy(isDeleted = false))
     }
 
     override suspend fun deleteAllDrafts() {
@@ -107,7 +125,8 @@ class CreationRepositoryImpl @Inject constructor(
     }
 
     override suspend fun deleteById(id: Long) {
-        dao.delete(dao.getById(id) ?: return)
+        val creation = dao.getById(id) ?: return
+        dao.delete(creation)
     }
 
 }

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/di/CreationModule.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/di/CreationModule.kt
@@ -35,7 +35,10 @@ import com.stoyanvuchev.magicmessage.domain.usecase.creation.CreationGetDraftsUs
 import com.stoyanvuchev.magicmessage.domain.usecase.creation.CreationGetExportedUseCase
 import com.stoyanvuchev.magicmessage.domain.usecase.creation.CreationMarkAsExportedUseCase
 import com.stoyanvuchev.magicmessage.domain.usecase.creation.CreationMarkAsFavoriteUseCase
+import com.stoyanvuchev.magicmessage.domain.usecase.creation.CreationModeToTrashUseCase
+import com.stoyanvuchev.magicmessage.domain.usecase.creation.CreationPermanentlyDeleteUseCase
 import com.stoyanvuchev.magicmessage.domain.usecase.creation.CreationRemoveAsFavoriteUseCase
+import com.stoyanvuchev.magicmessage.domain.usecase.creation.CreationRestoreDeletedUseCase
 import com.stoyanvuchev.magicmessage.domain.usecase.creation.CreationSaveOrUpdateUseCase
 import com.stoyanvuchev.magicmessage.domain.usecase.creation.CreationUseCases
 import dagger.Module
@@ -85,7 +88,10 @@ object CreationModule {
             getDraftsUseCase = CreationGetDraftsUseCase(repository),
             markAsExportedUseCase = CreationMarkAsExportedUseCase(repository),
             markAsFavoriteUseCase = CreationMarkAsFavoriteUseCase(repository),
-            removeAsFavoriteUseCase = CreationRemoveAsFavoriteUseCase(repository)
+            removeAsFavoriteUseCase = CreationRemoveAsFavoriteUseCase(repository),
+            restoreDeletedCreation = CreationRestoreDeletedUseCase(repository),
+            permanentlyDeleteCreation = CreationPermanentlyDeleteUseCase(repository),
+            moveCreationToTrash = CreationModeToTrashUseCase(repository)
         )
     }
 

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/domain/model/DrawConfiguration.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/domain/model/DrawConfiguration.kt
@@ -42,5 +42,5 @@ data class DrawConfiguration(
     val effect: BrushEffect = BrushEffect.BUBBLES,
     val thickness: BrushThickness = BrushThickness.MEDIUM,
     @Serializable(with = ColorSerializer::class) val color: Color = Color.White,
-    @Serializable(with = BackgroundLayerSerializer::class) val bgLayer: BackgroundLayer = DefaultBGLayers.linearGradientLayers.first()
+    @Stable @Serializable(with = BackgroundLayerSerializer::class) val bgLayer: BackgroundLayer = DefaultBGLayers.linearGradientLayers.first()
 )

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/domain/model/DrawingSnapshot.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/domain/model/DrawingSnapshot.kt
@@ -8,9 +8,9 @@ import kotlinx.serialization.Serializable
 data class DrawingSnapshot(
     val totalPointCount: Int,
     val drawingEnabled: Boolean,
-    val strokes: List<StrokeModel>,
-    val currentPoints: List<TimedPoint>,
-    val undoStack: List<StrokeModel>,
-    val redoStack: List<StrokeModel>,
+    @Stable val strokes: List<StrokeModel>,
+    @Stable val currentPoints: List<TimedPoint>,
+    @Stable val undoStack: List<StrokeModel>,
+    @Stable val redoStack: List<StrokeModel>,
     val startTime: Long
 )

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/domain/model/StrokeModel.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/domain/model/StrokeModel.kt
@@ -33,7 +33,7 @@ import kotlinx.serialization.Serializable
 @Serializable
 @Stable
 data class StrokeModel(
-    val points: List<TimedPoint>,
+    @Stable val points: List<TimedPoint>,
     @Serializable(with = ColorSerializer::class) val color: Color,
     val width: Float,
     val effect: BrushEffect = BrushEffect.NONE

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/domain/repository/CreationRepository.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/domain/repository/CreationRepository.kt
@@ -42,9 +42,20 @@ interface CreationRepository {
     suspend fun markAsFavorite(id: Long)
     suspend fun removeAsFavorite(id: Long)
 
-    fun getDrafts(onlyFavorite: Boolean): Flow<List<CreationModel>>
-    fun getFinished(onlyFavorite: Boolean): Flow<List<CreationModel>>
+    fun getDrafts(
+        onlyFavorite: Boolean,
+        deleted: Boolean
+    ): Flow<List<CreationModel>>
+
+    fun getFinished(
+        onlyFavorite: Boolean,
+        deleted: Boolean
+    ): Flow<List<CreationModel>>
+
     suspend fun getById(id: Long): CreationModel?
+
+    suspend fun moveCreationToTrash(creationId: Long)
+    suspend fun restoreDeletedCreation(creationId: Long)
 
     suspend fun deleteAllDrafts()
     suspend fun deleteAllCreations()

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/domain/usecase/creation/CreationGetDraftsUseCase.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/domain/usecase/creation/CreationGetDraftsUseCase.kt
@@ -34,9 +34,10 @@ class CreationGetDraftsUseCase @Inject constructor(
 ) {
 
     operator fun invoke(
-        onlyFavorite: Boolean = false
+        onlyFavorite: Boolean = false,
+        deleted: Boolean = false
     ): Flow<List<CreationModel>> {
-        return repository.getDrafts(onlyFavorite)
+        return repository.getDrafts(onlyFavorite, deleted)
     }
 
 }

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/domain/usecase/creation/CreationGetExportedUseCase.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/domain/usecase/creation/CreationGetExportedUseCase.kt
@@ -28,15 +28,17 @@ import com.stoyanvuchev.magicmessage.domain.model.CreationModel
 import com.stoyanvuchev.magicmessage.domain.repository.CreationRepository
 import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
+import kotlin.Boolean
 
 class CreationGetExportedUseCase @Inject constructor(
     private val repository: CreationRepository
 ) {
 
     operator fun invoke(
-        onlyFavorite: Boolean = false
+        onlyFavorite: Boolean = false,
+        deleted: Boolean = false
     ): Flow<List<CreationModel>> {
-        return repository.getFinished(onlyFavorite)
+        return repository.getFinished(onlyFavorite, deleted)
     }
 
 }

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/domain/usecase/creation/CreationModeToTrashUseCase.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/domain/usecase/creation/CreationModeToTrashUseCase.kt
@@ -22,18 +22,17 @@
  * SOFTWARE.
  */
 
-package com.stoyanvuchev.magicmessage.domain.model
+package com.stoyanvuchev.magicmessage.domain.usecase.creation
 
-import androidx.compose.runtime.Stable
-import kotlinx.serialization.Serializable
+import com.stoyanvuchev.magicmessage.domain.repository.CreationRepository
+import javax.inject.Inject
 
-@Stable
-@Serializable
-data class CreationModel(
-    val id: Long?,
-    val createdAt: Long,
-    val isDraft: Boolean,
-    val isFavorite: Boolean,
-    @Stable val drawConfiguration: DrawConfiguration,
-    @Stable val drawingSnapshot: DrawingSnapshot
-)
+class CreationModeToTrashUseCase @Inject constructor(
+    private val repository: CreationRepository
+) {
+
+    suspend operator fun invoke(creationId: Long) {
+        repository.moveCreationToTrash(creationId)
+    }
+
+}

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/domain/usecase/creation/CreationPermanentlyDeleteUseCase.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/domain/usecase/creation/CreationPermanentlyDeleteUseCase.kt
@@ -22,18 +22,17 @@
  * SOFTWARE.
  */
 
-package com.stoyanvuchev.magicmessage.domain.model
+package com.stoyanvuchev.magicmessage.domain.usecase.creation
 
-import androidx.compose.runtime.Stable
-import kotlinx.serialization.Serializable
+import com.stoyanvuchev.magicmessage.domain.repository.CreationRepository
+import javax.inject.Inject
 
-@Stable
-@Serializable
-data class CreationModel(
-    val id: Long?,
-    val createdAt: Long,
-    val isDraft: Boolean,
-    val isFavorite: Boolean,
-    @Stable val drawConfiguration: DrawConfiguration,
-    @Stable val drawingSnapshot: DrawingSnapshot
-)
+class CreationPermanentlyDeleteUseCase @Inject constructor(
+    private val repository: CreationRepository
+) {
+
+    suspend operator fun invoke(creationId: Long) {
+        repository.deleteById(creationId)
+    }
+
+}

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/domain/usecase/creation/CreationRestoreDeletedUseCase.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/domain/usecase/creation/CreationRestoreDeletedUseCase.kt
@@ -22,18 +22,17 @@
  * SOFTWARE.
  */
 
-package com.stoyanvuchev.magicmessage.domain.model
+package com.stoyanvuchev.magicmessage.domain.usecase.creation
 
-import androidx.compose.runtime.Stable
-import kotlinx.serialization.Serializable
+import com.stoyanvuchev.magicmessage.domain.repository.CreationRepository
+import javax.inject.Inject
 
-@Stable
-@Serializable
-data class CreationModel(
-    val id: Long?,
-    val createdAt: Long,
-    val isDraft: Boolean,
-    val isFavorite: Boolean,
-    @Stable val drawConfiguration: DrawConfiguration,
-    @Stable val drawingSnapshot: DrawingSnapshot
-)
+class CreationRestoreDeletedUseCase @Inject constructor(
+    private val repository: CreationRepository
+) {
+
+    suspend operator fun invoke(creationId: Long) {
+        repository.restoreDeletedCreation(creationId)
+    }
+
+}

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/domain/usecase/creation/CreationUseCases.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/domain/usecase/creation/CreationUseCases.kt
@@ -31,5 +31,8 @@ data class CreationUseCases(
     val getDraftsUseCase: CreationGetDraftsUseCase,
     val markAsExportedUseCase: CreationMarkAsExportedUseCase,
     val markAsFavoriteUseCase: CreationMarkAsFavoriteUseCase,
-    val removeAsFavoriteUseCase: CreationRemoveAsFavoriteUseCase
+    val removeAsFavoriteUseCase: CreationRemoveAsFavoriteUseCase,
+    val restoreDeletedCreation: CreationRestoreDeletedUseCase,
+    val permanentlyDeleteCreation: CreationPermanentlyDeleteUseCase,
+    val moveCreationToTrash: CreationModeToTrashUseCase
 )

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/framework/export/Exporter.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/framework/export/Exporter.kt
@@ -1,3 +1,27 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2025 Stoyan Vuchev
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES, OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package com.stoyanvuchev.magicmessage.framework.export
 
 import android.content.ContentValues

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/framework/service/ExportGifService.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/framework/service/ExportGifService.kt
@@ -44,6 +44,7 @@ import com.stoyanvuchev.magicmessage.framework.export.ExporterState
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
@@ -90,11 +91,11 @@ class ExportGifService : Service() {
         val height = intent?.getIntExtra("height", 0) ?: 1920
         val messageId = intent?.getLongExtra("messageId", 0L) ?: 0L
 
-        CoroutineScope(Dispatchers.Default).launch {
+        CoroutineScope(Dispatchers.Default + SupervisorJob()).launch {
 
             progressObserver.updateExporterState(ExporterState.EXPORTING)
 
-            val uri = exporter.exportGif(
+            exporter.exportGif(
                 strokes = ExportDataHolder.strokes,
                 width = width,
                 height = height,
@@ -102,9 +103,7 @@ class ExportGifService : Service() {
             ) { progress ->
                 progressObserver.updateProgress(progress)
                 updateProgress(progress)
-            }
-
-            uri?.let {
+            }?.let {
 
                 withContext(Dispatchers.IO) {
                     creationUseCases.markAsExportedUseCase(messageId = messageId)

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/AppNavHost.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/AppNavHost.kt
@@ -25,6 +25,7 @@
 package com.stoyanvuchev.magicmessage.presentation
 
 import android.annotation.SuppressLint
+import androidx.compose.animation.ExperimentalSharedTransitionApi
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
@@ -43,6 +44,7 @@ import com.stoyanvuchev.magicmessage.presentation.boarding.boardingNavGraph
 import com.stoyanvuchev.magicmessage.presentation.main.MainScreen
 import com.stoyanvuchev.magicmessage.presentation.main.mainNavGraph
 
+@OptIn(ExperimentalSharedTransitionApi::class)
 @SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
 @Composable
 fun AppNavHost(

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/ExportDialog.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/ExportDialog.kt
@@ -31,6 +31,7 @@ import android.net.Uri
 import androidx.compose.animation.animateContentSize
 import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.spring
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -46,10 +47,11 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -210,17 +212,23 @@ fun ExportDialog(
                         exportedUri?.let {
 
                             val context = LocalContext.current
-                            val painter = rememberDrawablePainter(
-                                drawable = createAnimatedImageDrawableFromImageDecoder(context, it)
-                            )
+                            val drawable = remember {
+                                createAnimatedImageDrawableFromImageDecoder(context, it)
+                            }
 
-                            Image(
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .aspectRatio(3f / 4f),
-                                painter = painter,
-                                contentDescription = null
-                            )
+                            if (drawable != null) {
+
+                                val painter = rememberDrawablePainter(drawable = drawable)
+
+                                Image(
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .aspectRatio(3f / 4f),
+                                    painter = painter,
+                                    contentDescription = null
+                                )
+
+                            }
 
                             Spacer(modifier = Modifier.height(16.dp))
 
@@ -229,38 +237,59 @@ fun ExportDialog(
                         Row(
                             modifier = Modifier.fillMaxWidth(),
                             verticalAlignment = Alignment.CenterVertically,
-                            horizontalArrangement = Arrangement.End
+                            horizontalArrangement = Arrangement.spacedBy(
+                                8.dp,
+                                Alignment.End
+                            )
                         ) {
 
                             val uriHandler = LocalUriHandler.current
 
-                            TextButton(
+                            OutlinedButton(
                                 onClick = onDismissExportDialog,
-                                colors = ButtonDefaults.textButtonColors(
-                                    contentColor = Theme.colors.primary
+                                colors = ButtonDefaults.elevatedButtonColors(
+                                    containerColor = Theme.colors.surfaceElevationHigh,
+                                    contentColor = Theme.colors.onSurfaceElevationHigh
+                                ),
+                                shape = Theme.shapes.largeShape,
+                                border = BorderStroke(
+                                    width = 1.dp,
+                                    color = Theme.colors.outline
                                 )
                             ) {
+
                                 Text(
                                     text = stringResource(R.string.exporter_label_cancel),
                                     style = Theme.typefaces.bodyLarge
                                 )
+
                             }
 
-                            TextButton(
-                                onClick = {
-                                    exportedUri?.let {
-                                        uriHandler.openUri(it.toString())
-                                        onDismissExportDialog()
+                            OutlinedButton(
+                                onClick = remember {
+                                    {
+                                        exportedUri?.let {
+                                            uriHandler.openUri(it.toString())
+                                            onDismissExportDialog()
+                                        }
                                     }
                                 },
-                                colors = ButtonDefaults.textButtonColors(
-                                    contentColor = Theme.colors.primary
+                                colors = ButtonDefaults.elevatedButtonColors(
+                                    containerColor = Theme.colors.primary,
+                                    contentColor = Theme.colors.onPrimary
+                                ),
+                                shape = Theme.shapes.largeShape,
+                                border = BorderStroke(
+                                    width = 1.dp,
+                                    color = Theme.colors.outline
                                 )
                             ) {
+
                                 Text(
                                     text = stringResource(R.string.exporter_label_view),
                                     style = Theme.typefaces.bodyLarge
                                 )
+
                             }
 
                         }
@@ -280,8 +309,13 @@ fun ExportDialog(
 private fun createAnimatedImageDrawableFromImageDecoder(
     context: Context,
     uri: Uri
-): AnimatedImageDrawable {
+): AnimatedImageDrawable? {
     val source = ImageDecoder.createSource(context.contentResolver, uri)
     val drawable = ImageDecoder.decodeDrawable(source)
-    return drawable as AnimatedImageDrawable
+    return try {
+        drawable as AnimatedImageDrawable
+    } catch (e: Exception) {
+        e.printStackTrace()
+        null
+    }
 }

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/main/MainScreen.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/main/MainScreen.kt
@@ -69,6 +69,12 @@ sealed class MainScreen(
         icon = R.drawable.logo_icon
     )
 
+    @Serializable
+    data object Deleted : MainScreen(
+        label = R.string.deleted_screen_label,
+        icon = R.drawable.delete
+    )
+
 }
 
 val mainScreenNavDestinations: List<MainScreen> = listOf(

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/main/deleted_screen/DeletedScreen.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/main/deleted_screen/DeletedScreen.kt
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-package com.stoyanvuchev.magicmessage.presentation.main.home_screen
+package com.stoyanvuchev.magicmessage.presentation.main.deleted_screen
 
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedVisibility
@@ -37,7 +37,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.grid.rememberLazyGridState
-import androidx.compose.material3.FabPosition
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Scaffold
@@ -55,22 +54,19 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import com.stoyanvuchev.magicmessage.R
-import com.stoyanvuchev.magicmessage.core.ui.components.AuraButton
-import com.stoyanvuchev.magicmessage.core.ui.components.EmptyBottomSpacer
-import com.stoyanvuchev.magicmessage.core.ui.components.grid.GridCreationItemDetailsLayout
+import com.stoyanvuchev.magicmessage.core.ui.components.grid.GridDeletedCreationItemDetailsLayout
 import com.stoyanvuchev.magicmessage.core.ui.components.grid.GridOfCreationItems
 import com.stoyanvuchev.magicmessage.core.ui.components.grid.gridOfCreationItemsSection
 import com.stoyanvuchev.magicmessage.core.ui.components.top_bar.TopBar
 import com.stoyanvuchev.magicmessage.core.ui.event.NavigationEvent
 import com.stoyanvuchev.magicmessage.core.ui.theme.Theme
 import com.stoyanvuchev.magicmessage.domain.model.CreationModel
-import com.stoyanvuchev.magicmessage.presentation.main.MainScreen
 
 @OptIn(ExperimentalSharedTransitionApi::class)
 @Composable
-fun HomeScreen(
-    state: HomeScreenState,
-    onUIAction: (HomeScreenUIAction) -> Unit,
+fun DeletedScreen(
+    state: DeletedScreenState,
+    onUIAction: (DeletedScreenUIAction) -> Unit,
     onNavigationEvent: (NavigationEvent) -> Unit
 ) {
 
@@ -89,7 +85,20 @@ fun HomeScreen(
         topBar = {
 
             TopBar(
-                title = { Text(text = stringResource(R.string.home_screen_label)) },
+                title = { Text(text = stringResource(R.string.deleted_screen_label)) },
+                navigationAction = {
+
+                    IconButton(
+                        onClick = remember { { onNavigationEvent(NavigationEvent.NavigateUp) } }
+                    ) {
+                        Icon(
+                            modifier = Modifier.size(28.dp),
+                            painter = painterResource(R.drawable.arrow_left_outlined),
+                            contentDescription = stringResource(R.string.navigate_back)
+                        )
+                    }
+
+                },
                 actions = {
 
                     AnimatedVisibility(
@@ -115,38 +124,7 @@ fun HomeScreen(
                 }
             )
 
-        },
-        floatingActionButtonPosition = FabPosition.Center,
-        floatingActionButton = {
-
-            if (sharedCreation == null) {
-
-                AuraButton(
-                    onClick = remember {
-                        {
-                            onNavigationEvent(
-                                NavigationEvent.NavigateTo(
-                                    MainScreen.Draw(null)
-                                )
-                            )
-                        }
-                    },
-                    isGlowVisible = true,
-                    size = 56.dp
-                ) {
-
-                    Icon(
-                        modifier = Modifier.size(24.dp),
-                        painter = painterResource(R.drawable.pencil_icon),
-                        contentDescription = null
-                    )
-
-                }
-
-            }
-
-        },
-        bottomBar = { EmptyBottomSpacer() }
+        }
     ) { innerPadding ->
 
         SharedTransitionLayout {
@@ -172,13 +150,13 @@ fun HomeScreen(
                 ) {
 
                     Icon(
-                        modifier = Modifier.size(100.dp),
-                        painter = painterResource(R.drawable.logo_icon),
+                        modifier = Modifier.size(80.dp),
+                        painter = painterResource(R.drawable.delete),
                         contentDescription = null
                     )
 
                     Text(
-                        text = stringResource(R.string.home_screen_empty_text),
+                        text = stringResource(R.string.deleted_screen_empty_text),
                         style = Theme.typefaces.bodyLarge,
                         color = Theme.colors.onSurfaceElevationLow.copy(.5f)
                     )
@@ -188,16 +166,6 @@ fun HomeScreen(
             }
 
             var canvasSize by remember { mutableStateOf(IntSize.Zero) }
-
-            val onCreationClickLambda = remember<(CreationModel, IntSize) -> Unit> {
-                { creation, _ ->
-                    onNavigationEvent(
-                        NavigationEvent.NavigateTo(
-                            MainScreen.Draw(creation.id)
-                        )
-                    )
-                }
-            }
 
             val onCreationLongClickLambda = remember<(CreationModel, IntSize) -> Unit> {
                 { creation, newCanvasSize ->
@@ -214,16 +182,16 @@ fun HomeScreen(
                 isLightWeightBlurApplied = isLightWeightBlurApplied,
                 lazyGridState = lazyGridState,
                 innerPadding = innerPadding,
-                hazeSourceKey = "home_screen_grid_key"
+                hazeSourceKey = "deleted_screen_grid_key"
             ) {
 
                 gridOfCreationItemsSection(
                     sharedTransitionScope = this@SharedTransitionLayout,
                     label = R.string.drafts_label,
                     items = state.draftedCreationsList,
-                    categoryKey = "home_drafted_items",
+                    categoryKey = "deleted_drafted_items",
                     sharedCreation = sharedCreation,
-                    onCreationClick = onCreationClickLambda,
+                    onCreationClick = onCreationLongClickLambda,
                     onCreationLongClick = onCreationLongClickLambda
                 )
 
@@ -231,31 +199,24 @@ fun HomeScreen(
                     sharedTransitionScope = this@SharedTransitionLayout,
                     label = R.string.exported_label,
                     items = state.exportedCreationsList,
-                    categoryKey = "home_exported_items",
+                    categoryKey = "deleted_exported_items",
                     sharedCreation = sharedCreation,
-                    onCreationClick = onCreationClickLambda,
+                    onCreationClick = onCreationLongClickLambda,
                     onCreationLongClick = onCreationLongClickLambda
                 )
 
             }
 
-            GridCreationItemDetailsLayout(
+            GridDeletedCreationItemDetailsLayout(
                 innerPadding = innerPadding,
                 creation = sharedCreation,
                 canvasSize = canvasSize,
                 onDismiss = remember { { sharedCreation = null } },
-                onCreationClick = onCreationClickLambda,
-                onExportGif = remember {
-                    { onUIAction(HomeScreenUIAction.ExportGif(it)) }
+                onRestore = remember {
+                    { onUIAction(DeletedScreenUIAction.RestoreCreation(it)) }
                 },
-                onMarkAsFavorite = remember {
-                    { onUIAction(HomeScreenUIAction.AddToFavorite(it)) }
-                },
-                onRemoveAsFavorite = remember {
-                    { onUIAction(HomeScreenUIAction.RemoveFromFavorite(it)) }
-                },
-                onMoveToTrash = remember {
-                    { onUIAction(HomeScreenUIAction.MoveToTrash(it)) }
+                onPermanentlyDelete = remember {
+                    { onUIAction(DeletedScreenUIAction.PermanentlyDeleteCreation(it)) }
                 }
             )
 

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/main/deleted_screen/DeletedScreenState.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/main/deleted_screen/DeletedScreenState.kt
@@ -22,18 +22,13 @@
  * SOFTWARE.
  */
 
-package com.stoyanvuchev.magicmessage.domain.model
+package com.stoyanvuchev.magicmessage.presentation.main.deleted_screen
 
 import androidx.compose.runtime.Stable
-import kotlinx.serialization.Serializable
+import com.stoyanvuchev.magicmessage.domain.model.CreationModel
 
 @Stable
-@Serializable
-data class CreationModel(
-    val id: Long?,
-    val createdAt: Long,
-    val isDraft: Boolean,
-    val isFavorite: Boolean,
-    @Stable val drawConfiguration: DrawConfiguration,
-    @Stable val drawingSnapshot: DrawingSnapshot
+data class DeletedScreenState(
+    @Stable val draftedCreationsList: List<CreationModel> = emptyList(),
+    @Stable val exportedCreationsList: List<CreationModel> = emptyList()
 )

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/main/deleted_screen/DeletedScreenUIAction.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/main/deleted_screen/DeletedScreenUIAction.kt
@@ -22,18 +22,19 @@
  * SOFTWARE.
  */
 
-package com.stoyanvuchev.magicmessage.domain.model
+package com.stoyanvuchev.magicmessage.presentation.main.deleted_screen
 
 import androidx.compose.runtime.Stable
-import kotlinx.serialization.Serializable
 
 @Stable
-@Serializable
-data class CreationModel(
-    val id: Long?,
-    val createdAt: Long,
-    val isDraft: Boolean,
-    val isFavorite: Boolean,
-    @Stable val drawConfiguration: DrawConfiguration,
-    @Stable val drawingSnapshot: DrawingSnapshot
-)
+sealed interface DeletedScreenUIAction {
+
+    data class RestoreCreation(
+        val creationId: Long
+    ) : DeletedScreenUIAction
+
+    data class PermanentlyDeleteCreation(
+        val creationId: Long
+    ) : DeletedScreenUIAction
+
+}

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/main/draw_screen/DrawScreenTopBar.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/main/draw_screen/DrawScreenTopBar.kt
@@ -27,7 +27,6 @@ package com.stoyanvuchev.magicmessage.presentation.main.draw_screen
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
@@ -49,7 +48,7 @@ fun DrawScreenTopBar(
     onUIAction: (DrawScreenUIAction) -> Unit,
     onNavigationEvent: (NavigationEvent) -> Unit
 ) = TopBar(
-    title = { Text(text = stringResource(R.string.app_name)) },
+    title = remember { {} },
     navigationAction = {
 
         IconButton(

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/main/draw_screen/DrawScreenViewModel.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/main/draw_screen/DrawScreenViewModel.kt
@@ -163,9 +163,11 @@ class DrawScreenViewModel @Inject constructor(
     }
 
     private fun exportGif(action: DrawScreenUIAction.Export) {
-        ExportDataHolder.strokes = _drawingController.value.strokes
-        ExportDataHolder.bgLayer = _state.value.drawConfiguration.bgLayer
-        sendUIAction(action)
+        if (_drawingController.value.strokes.isNotEmpty()) {
+            ExportDataHolder.strokes = _drawingController.value.strokes
+            ExportDataHolder.bgLayer = _state.value.drawConfiguration.bgLayer
+            sendUIAction(action)
+        }
     }
 
     private fun sendUIAction(action: DrawScreenUIAction) {

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/main/draw_screen/dialog/DrawScreenDialogBGLayerItem.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/main/draw_screen/dialog/DrawScreenDialogBGLayerItem.kt
@@ -34,12 +34,11 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.aspectRatio
-import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -47,6 +46,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.res.stringResource
@@ -104,9 +104,7 @@ fun DrawScreenDialogBGLayerItem(
 
                 Box(
                     modifier = Modifier
-                        .defaultMinSize(48.dp)
-                        .weight(1f)
-                        .aspectRatio(1f)
+                        .size(48.dp)
                         .clickable(
                             onClick = remember {
                                 {
@@ -187,9 +185,7 @@ fun DrawScreenDialogBGLayerItem(
 
                 Box(
                     modifier = Modifier
-                        .defaultMinSize(64.dp)
-                        .weight(1f)
-                        .aspectRatio(1f)
+                        .size(72.dp)
                         .clickable(
                             onClick = remember {
                                 {
@@ -218,12 +214,14 @@ fun DrawScreenDialogBGLayerItem(
                         modifier = Modifier
                             .padding(8.dp)
                             .fillMaxSize()
+                            .clip(Theme.shapes.smallShape)
                             .border(
                                 width = 1.dp,
                                 color = Theme.colors.onSurfaceElevationLow.copy(.5f),
                                 shape = Theme.shapes.smallShape
                             )
                             .padding(3.dp)
+                            .clip(Theme.shapes.verySmallShape)
                             .background(
                                 brush = Brush.linearGradient(
                                     colors = layer.colors,

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/main/favorite_screen/FavoriteScreenState.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/main/favorite_screen/FavoriteScreenState.kt
@@ -29,6 +29,6 @@ import com.stoyanvuchev.magicmessage.domain.model.CreationModel
 
 @Stable
 class FavoriteScreenState(
-    val draftedCreationsList: List<CreationModel> = emptyList(),
-    val exportedCreationsList: List<CreationModel> = emptyList()
+    @Stable val draftedCreationsList: List<CreationModel> = emptyList(),
+    @Stable val exportedCreationsList: List<CreationModel> = emptyList()
 )

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/main/favorite_screen/FavoriteScreenUIAction.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/main/favorite_screen/FavoriteScreenUIAction.kt
@@ -30,6 +30,10 @@ import com.stoyanvuchev.magicmessage.domain.model.CreationModel
 @Stable
 interface FavoriteScreenUIAction {
 
+    data class MoveToTrash(
+        val creationId: Long
+    ) : FavoriteScreenUIAction
+
     data class RemoveFromFavorite(
         val creationId: Long?
     ) : FavoriteScreenUIAction

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/main/home_screen/HomeScreenState.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/main/home_screen/HomeScreenState.kt
@@ -29,6 +29,6 @@ import com.stoyanvuchev.magicmessage.domain.model.CreationModel
 
 @Stable
 data class HomeScreenState(
-    val exportedCreationsList: List<CreationModel> = emptyList(),
-    val draftedCreationsList: List<CreationModel> = emptyList()
+    @Stable val exportedCreationsList: List<CreationModel> = emptyList(),
+    @Stable val draftedCreationsList: List<CreationModel> = emptyList()
 )

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/main/home_screen/HomeScreenUIAction.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/main/home_screen/HomeScreenUIAction.kt
@@ -30,6 +30,10 @@ import com.stoyanvuchev.magicmessage.domain.model.CreationModel
 @Stable
 interface HomeScreenUIAction {
 
+    data class MoveToTrash(
+        val creationId: Long
+    ) : HomeScreenUIAction
+
     data class RemoveFromFavorite(
         val creationId: Long?
     ) : HomeScreenUIAction

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/main/menu_screen/MenuScreen.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/main/menu_screen/MenuScreen.kt
@@ -51,6 +51,7 @@ import com.stoyanvuchev.magicmessage.core.ui.components.RowSelectionItem
 import com.stoyanvuchev.magicmessage.core.ui.components.list.ListOfOptionItems
 import com.stoyanvuchev.magicmessage.core.ui.components.list.ListOptionItemDetailsLayout
 import com.stoyanvuchev.magicmessage.core.ui.components.top_bar.TopBar
+import com.stoyanvuchev.magicmessage.core.ui.event.NavigationEvent
 import com.stoyanvuchev.magicmessage.core.ui.theme.LocalThemeMode
 import com.stoyanvuchev.magicmessage.core.ui.theme.Theme
 import com.stoyanvuchev.magicmessage.core.ui.theme.ThemeMode
@@ -61,7 +62,8 @@ import com.stoyanvuchev.magicmessage.core.ui.transition.defaultBoundsTransformat
 @OptIn(ExperimentalSharedTransitionApi::class)
 @Composable
 fun MenuScreen(
-    onUIAction: (MenuScreenUIAction) -> Unit
+    onUIAction: (MenuScreenUIAction) -> Unit,
+    onNavigationEvent: (NavigationEvent) -> Unit
 ) {
 
     val lazyListState = rememberLazyListState()
@@ -110,7 +112,12 @@ fun MenuScreen(
 
         SharedTransitionLayout {
 
+            val isLightWeightBlueApplied by rememberUpdatedState(
+                sharedKey != null
+            )
+
             ListOfOptionItems(
+                isLightWeightBlueApplied = isLightWeightBlueApplied,
                 lazyListState = lazyListState,
                 innerPadding = innerPadding,
                 hazeSourceKey = "menu_screen_list_key"
@@ -127,7 +134,7 @@ fun MenuScreen(
                     sharedTransitionScope = this@SharedTransitionLayout,
                     sharedKey = sharedKey,
                     boundsTransform = boundsTransform,
-                    onSharedKey = onSharedKeyLambda
+                    onNavigationEvent = onNavigationEvent
                 )
 
                 menuScreenOtherSection(

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/main/menu_screen/MenuScreenCreationSection.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/main/menu_screen/MenuScreenCreationSection.kt
@@ -44,13 +44,15 @@ import com.stoyanvuchev.magicmessage.R
 import com.stoyanvuchev.magicmessage.core.ui.components.list.ListOptionItem
 import com.stoyanvuchev.magicmessage.core.ui.components.list.listOfOptionItemsSelection
 import com.stoyanvuchev.magicmessage.core.ui.etc.UIString
+import com.stoyanvuchev.magicmessage.core.ui.event.NavigationEvent
+import com.stoyanvuchev.magicmessage.presentation.main.MainScreen
 
 @OptIn(ExperimentalSharedTransitionApi::class)
 fun LazyListScope.menuScreenCreationSection(
     sharedTransitionScope: SharedTransitionScope,
     sharedKey: String?,
     boundsTransform: (Rect, Rect) -> SpringSpec<Rect>,
-    onSharedKey: (String?) -> Unit
+    onNavigationEvent: (NavigationEvent) -> Unit
 ) = listOfOptionItemsSelection(
     sharedTransitionScope = sharedTransitionScope,
     label = UIString.Resource(resId = R.string.menu_screen_creations_label),
@@ -63,7 +65,15 @@ fun LazyListScope.menuScreenCreationSection(
         item(key = "${categoryKey}_trash") {
 
             val deletedKey = remember { "trash" }
-            val onSharedKeyLambda = remember { { /*TODO*/ } }
+            val onSharedKeyLambda = remember {
+                {
+                    onNavigationEvent(
+                        NavigationEvent.NavigateTo(
+                            MainScreen.Deleted
+                        )
+                    )
+                }
+            }
 
             AnimatedVisibility(
                 modifier = Modifier

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/main/transitions/FavoriteNavigationTransitions.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/main/transitions/FavoriteNavigationTransitions.kt
@@ -27,6 +27,8 @@ package com.stoyanvuchev.magicmessage.presentation.main.transitions
 import androidx.compose.animation.AnimatedContentTransitionScope
 import androidx.compose.animation.EnterTransition
 import androidx.compose.animation.ExitTransition
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
 import androidx.compose.runtime.Stable
 import androidx.navigation.NavBackStackEntry
 import com.stoyanvuchev.magicmessage.core.ui.navigation.NavigationScreen
@@ -58,6 +60,10 @@ object FavoriteNavigationTransitions : NavigationTransitions {
                 )
             }
 
+            initialRoute is MainScreen.Favorite && targetRoute is MainScreen.Draw -> {
+                fadeIn()
+            }
+
             else -> DefaultTransitions.Enter.fadeInWithScaleIn(
                 initialScale = DefaultTransitions.INITIAL_SCALE
             )
@@ -84,6 +90,10 @@ object FavoriteNavigationTransitions : NavigationTransitions {
                     scope = scope,
                     slideDirection = AnimatedContentTransitionScope.SlideDirection.Start
                 )
+            }
+
+            initialRoute is MainScreen.Favorite && targetRoute is MainScreen.Draw -> {
+                fadeOut()
             }
 
             else -> DefaultTransitions.Exit.fadeOutWithScaleOut(
@@ -114,6 +124,10 @@ object FavoriteNavigationTransitions : NavigationTransitions {
                 )
             }
 
+            initialRoute is MainScreen.Draw && targetRoute is MainScreen.Favorite -> {
+                fadeIn()
+            }
+
             else -> DefaultTransitions.Enter.fadeInWithScaleIn(
                 initialScale = DefaultTransitions.INITIAL_POP_SCALE
             )
@@ -140,6 +154,10 @@ object FavoriteNavigationTransitions : NavigationTransitions {
                     scope = scope,
                     slideDirection = AnimatedContentTransitionScope.SlideDirection.Start
                 )
+            }
+
+            initialRoute is MainScreen.Favorite && targetRoute is MainScreen.Draw -> {
+                fadeOut()
             }
 
             else -> DefaultTransitions.Exit.fadeOutWithScaleOut(

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/main/transitions/MainScreenSafeRoute.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/main/transitions/MainScreenSafeRoute.kt
@@ -25,15 +25,16 @@
 package com.stoyanvuchev.magicmessage.presentation.main.transitions
 
 import androidx.navigation.NavBackStackEntry
+import androidx.navigation.NavDestination.Companion.hasRoute
 import com.stoyanvuchev.magicmessage.core.ui.navigation.NavigationScreen
 import com.stoyanvuchev.magicmessage.presentation.main.MainScreen
 
 fun NavBackStackEntry.safeRoute(): NavigationScreen? {
-    return when (destination.route) {
-        MainScreen.Home::class.qualifiedName -> MainScreen.Home
-        MainScreen.Favorite::class.qualifiedName -> MainScreen.Favorite
-        MainScreen.Menu::class.qualifiedName -> MainScreen.Menu
-        MainScreen.Draw::class.qualifiedName -> MainScreen.Draw(null)
+    return when {
+        destination.hasRoute<MainScreen.Home>() -> MainScreen.Home
+        destination.hasRoute<MainScreen.Favorite>() -> MainScreen.Favorite
+        destination.hasRoute<MainScreen.Menu>() -> MainScreen.Menu
+        destination.hasRoute<MainScreen.Draw>() -> MainScreen.Draw(null)
         else -> null
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -56,4 +56,11 @@
     <string name="menu_screen_creations_label">Creations</string>
     <string name="about_label">About the app</string>
     <string name="menu_screen_other_label">Other</string>
+    <string name="deleted_screen_label">Trash</string>
+    <string name="restore">Restore</string>
+    <string name="delete">Delete</string>
+    <string name="deleted_screen_empty_text">The trash is empty.</string>
+    <string name="delete_screen_confirm_delete_description">This action will delete the creation from the app, but not the export. This action can NOT be undone!</string>
+    <string name="delete_label_cancel">Cancel</string>
+    <string name="delete_label_permanently">Delete</string>
 </resources>


### PR DESCRIPTION
This commit introduces a "Trash" feature for soft-deleting creations, enhances UI interactions in Home and Favorite screens, and refines various components and transitions.

**Key Changes:**

- **Trash Functionality:**
    - Added `isDeleted` flag to `CreationEntity` and `CreationModel`.
    - Implemented `moveCreationToTrash`, `restoreDeletedCreation`, and `permanentlyDeleteCreation` use cases and repository methods.
    - `CreationDao` updated to filter queries based on the `isDeleted` flag.
    - Introduced `DeletedScreen` to display and manage trashed items.
        - Users can restore or permanently delete items from this screen.
        - `GridDeletedCreationItemDetailsLayout` provides actions for trashed items.
    - Integrated "Move to Trash" option in `HomeScreen` and `FavoriteScreen` item detail views.

- **UI/UX Enhancements:**
    - **Home & Favorite Screens:** - Refactored `GridOfCreationItemsSection` for cleaner item and label display. - Improved `GridCreationItemDetailsLayout`: - Actions (Export, Favorite, Trash) are now part of this layout. - Uses `defaultLightWeightBlur` when details are shown. - `GridOfCreationItems` now applies `defaultLightWeightBlur` to the grid when an item's details are displayed. - `onCreationClick` in `GridCreationItem` now passes `canvasSize`.
    - **Menu Screen:**
        - Added navigation to `DeletedScreen` from the "Creations" section.
        - `ListOfOptionItems` now applies `defaultLightWeightBlur` when an item's details (like Theme selection) are shown.
    - **Draw Screen:** - `DrawScreenTopBar` title removed for a cleaner look. - Exporting a GIF is now conditional on having strokes drawn.
    - **RowSelectionItem:** Adjusted background and border alpha for better visual feedback.
    - **ListOptionItemDetailsLayout:** Replaced `defaultHazeEffect` with a semi-transparent background.
    - **ExportDialog:**
        - Updated button styling (OutlinedButtons).
        - Improved handling of `AnimatedImageDrawable` creation.
    - **Transitions:** - Adjusted `DefaultTransitions` spring animation for a slightly bouncier feel. - Refined transitions between `FavoriteScreen` and `DrawScreen`. - `MainNavGraph` now uses simple fade transitions for `DrawScreen` and `DeletedScreen`.
    - **Visuals:**
        - Introduced `defaultLightWeightBlur` modifier for a consistent blur effect.
        - Updated `outline` color in `ColorPaletteTokens` for better contrast. - Minor UI tweaks in `DrawScreenDialogBGLayerItem` for consistent sizing and borders.

- **Code & Performance:**
    - Added `@Stable` annotations to various model classes (`StrokeModel`, `HomeScreenState`, `FavoriteScreenState`, `DrawingSnapshot`, `DrawConfiguration`, `CreationModel`) for Compose stability.
    - `HomeScreenViewModel` and `FavoriteScreenViewModel`:
        - Simplified state combination.
        - Removed unnecessary `Dispatchers.IO` context switches for database operations.
    - `AppPreferencesImpl`: Default `ThemeMode` changed from `Dark` to `System`.
    - `MenuScreenViewModel`: Added navigation event handling.
    - `CreationModule`: Added new use cases for trash functionality.
    - `defaultHazeEffect` and `defaultLightWeightBlur` made `composed` modifiers.
    - Version bumped to `0.1.1`.

- **Resource Updates:**
    - Added new string resources for Trash functionality and labels.
    - Added copyright header to `Exporter.kt`.
    - New `DefaultLightweightBlur.kt` file.

- **Minor Fixes & Refinements:**
    - `BackHandler` usage standardized in `HomeScreen` and `FavoriteScreen`.
    - `safeRoute` in `MainScreenSafeRoute` now uses `destination.hasRoute<T>()`.