### PR TITLE
Implemented customizable ColorScheme and integrated it into the app.

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -4,10 +4,10 @@
     <selectionStates>
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
-        <DropdownSelection timestamp="2025-09-25T18:37:29.030659Z">
+        <DropdownSelection timestamp="2025-09-28T08:27:17.063003Z">
           <Target type="DEFAULT_BOOT">
             <handle>
-              <DeviceId pluginId="LocalEmulator" identifier="path=/Users/stoyan/.android/avd/Pixel_6_Pro.avd" />
+              <DeviceId pluginId="LocalEmulator" identifier="path=/Users/stoyan/.android/avd/Pixel_7_Pro.avd" />
             </handle>
           </Target>
         </DropdownSelection>

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/core/ui/components/AuraButton.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/core/ui/components/AuraButton.kt
@@ -24,6 +24,7 @@
 
 package com.stoyanvuchev.magicmessage.core.ui.components
 
+import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.RepeatMode
 import androidx.compose.animation.core.VectorConverter
 import androidx.compose.animation.core.animateFloatAsState
@@ -71,6 +72,9 @@ fun AuraButton(
     hazeState: HazeState = LocalHazeState.current,
     isGlowVisible: Boolean = true,
     glowColor: Color = Theme.colors.primary,
+    onGlowColor: Color = Theme.colors.onPrimary,
+    inactiveColor: Color = Theme.colors.surfaceElevationMedium,
+    onInactiveColor: Color = Theme.colors.onSurfaceElevationMedium,
     size: Dp = 48.dp,
     content: @Composable (() -> Unit)
 ) {
@@ -115,6 +119,16 @@ fun AuraButton(
         animationSpec = tween(durationMillis = 360)
     )
 
+    val containerColor by animateColorAsState(
+        targetValue = if (isGlowVisible) glowColor
+        else inactiveColor
+    )
+
+    val contentColor by animateColorAsState(
+        targetValue = if (isGlowVisible) onGlowColor
+        else onInactiveColor
+    )
+
     Box(
         modifier = Modifier
             .size(size)
@@ -135,7 +149,7 @@ fun AuraButton(
             .clip(CircleShape)
             .defaultHazeEffect(hazeState = hazeState)
             .background(
-                color = glowColor.copy(alpha.coerceIn(0f, .25f)),
+                color = containerColor,
                 shape = CircleShape
             )
             .border(
@@ -153,7 +167,7 @@ fun AuraButton(
     ) {
 
         CompositionLocalProvider(
-            LocalContentColor provides Theme.colors.onSurfaceElevationHigh,
+            LocalContentColor provides contentColor,
             content = content
         )
 

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/core/ui/theme/Theme.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/core/ui/theme/Theme.kt
@@ -28,7 +28,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.runtime.Stable
 import com.stoyanvuchev.magicmessage.core.ui.theme.color.ColorPalette
+import com.stoyanvuchev.magicmessage.core.ui.theme.color.ColorScheme
 import com.stoyanvuchev.magicmessage.core.ui.theme.color.LocalColorPalette
+import com.stoyanvuchev.magicmessage.core.ui.theme.color.toColorPalette
 import com.stoyanvuchev.magicmessage.core.ui.theme.shape.LocalShapes
 import com.stoyanvuchev.magicmessage.core.ui.theme.shape.Shapes
 import com.stoyanvuchev.magicmessage.core.ui.theme.typeface.LocalTypefaces
@@ -37,9 +39,11 @@ import com.stoyanvuchev.magicmessage.core.ui.theme.typeface.Typefaces
 @Composable
 fun MagicMessageTheme(
     themeMode: ThemeMode = LocalThemeMode.current,
+    colorScheme: ColorScheme = ColorScheme.BLUE,
     content: @Composable () -> Unit
 ) = UIWrapper(
     themeMode = themeMode,
+    colorPalette = colorScheme.toColorPalette(isInDarkThemeMode(themeMode)),
     content = content
 )
 

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/core/ui/theme/UIWrapper.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/core/ui/theme/UIWrapper.kt
@@ -27,7 +27,6 @@ package com.stoyanvuchev.magicmessage.core.ui.theme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect
-import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberUpdatedState
 import com.stoyanvuchev.magicmessage.core.ui.ext.LocalHazeState
@@ -35,8 +34,7 @@ import com.stoyanvuchev.magicmessage.core.ui.theme.color.ColorPalette
 import com.stoyanvuchev.magicmessage.core.ui.theme.color.LocalColorPalette
 import com.stoyanvuchev.magicmessage.core.ui.theme.color.LocalContentColor
 import com.stoyanvuchev.magicmessage.core.ui.theme.color.asAnimatedColorPalette
-import com.stoyanvuchev.magicmessage.core.ui.theme.color.darkColorPalette
-import com.stoyanvuchev.magicmessage.core.ui.theme.color.lightColorPalette
+import com.stoyanvuchev.magicmessage.core.ui.theme.color.getThemedColorPalette
 import com.stoyanvuchev.magicmessage.core.ui.theme.shape.LocalShapes
 import com.stoyanvuchev.magicmessage.core.ui.theme.shape.Shapes
 import com.stoyanvuchev.magicmessage.core.ui.theme.typeface.LocalTextStyle
@@ -49,8 +47,8 @@ import dev.chrisbanes.haze.rememberHazeState
 
 @Composable
 fun UIWrapper(
-    themeMode: ThemeMode = ThemeMode.System,
-    colorPalette: ColorPalette = getDefaultColorPalette(isInDarkThemeMode(themeMode)),
+    themeMode: ThemeMode = ThemeMode.SYSTEM,
+    colorPalette: ColorPalette = getThemedColorPalette(isInDarkThemeMode(themeMode)),
     animateColorPalette: Boolean = true,
     typefaces: Typefaces = Typefaces.Default,
     shapes: Shapes = Shapes.Default,
@@ -87,10 +85,4 @@ fun UIWrapper(
         content = content
     )
 
-}
-
-@Stable
-fun getDefaultColorPalette(darkTheme: Boolean): ColorPalette {
-    return (if (darkTheme) darkColorPalette()
-    else lightColorPalette())
 }

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/core/ui/theme/color/AnimatedColorPalette.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/core/ui/theme/color/AnimatedColorPalette.kt
@@ -55,6 +55,7 @@ fun ColorPalette.asAnimatedColorPalette(): ColorPalette {
     val animatedOutline by animateColor(this.outline)
 
     return ColorPalette(
+        scheme = this.scheme,
         primary = animatedPrimary,
         onPrimary = animatedOnPrimary,
         surfaceElevationLow = animatedSurfaceElevationLow,

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/core/ui/theme/color/ColorPalette.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/core/ui/theme/color/ColorPalette.kt
@@ -27,9 +27,13 @@ package com.stoyanvuchev.magicmessage.core.ui.theme.color
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.ui.graphics.Color
+import com.stoyanvuchev.magicmessage.core.ui.theme.color.tokens.BlueDarkColorPaletteTokens
+import com.stoyanvuchev.magicmessage.core.ui.theme.color.tokens.BlueLightColorPaletteTokens
+import com.stoyanvuchev.magicmessage.core.ui.theme.color.tokens.ColorPaletteTokens
 
 @Stable
 data class ColorPalette(
+    val scheme: ColorScheme,
     val primary: Color,
     val onPrimary: Color,
     val surfaceElevationLow: Color,
@@ -44,58 +48,32 @@ data class ColorPalette(
 )
 
 @Stable
-fun lightColorPalette(
-    primary: Color = LightColorPaletteTokens.primary,
-    onPrimary: Color = LightColorPaletteTokens.onPrimary,
-    surfaceElevationLow: Color = LightColorPaletteTokens.surfaceElevationLow,
-    onSurfaceElevationLow: Color = LightColorPaletteTokens.onSurfaceElevationLow,
-    surfaceElevationMedium: Color = LightColorPaletteTokens.surfaceElevationMedium,
-    onSurfaceElevationMedium: Color = LightColorPaletteTokens.onSurfaceElevationMedium,
-    surfaceElevationHigh: Color = LightColorPaletteTokens.surfaceElevationHigh,
-    onSurfaceElevationHigh: Color = LightColorPaletteTokens.onSurfaceElevationHigh,
-    error: Color = LightColorPaletteTokens.error,
-    onError: Color = LightColorPaletteTokens.onError,
-    outline: Color = LightColorPaletteTokens.outline
+fun colorPalette(
+    tokens: ColorPaletteTokens
 ) = ColorPalette(
-    primary = primary,
-    onPrimary = onPrimary,
-    surfaceElevationLow = surfaceElevationLow,
-    onSurfaceElevationLow = onSurfaceElevationLow,
-    surfaceElevationMedium = surfaceElevationMedium,
-    onSurfaceElevationMedium = onSurfaceElevationMedium,
-    surfaceElevationHigh = surfaceElevationHigh,
-    onSurfaceElevationHigh = onSurfaceElevationHigh,
-    error = error,
-    onError = onError,
-    outline = outline
+    scheme = tokens.scheme,
+    primary = tokens.primary,
+    onPrimary = tokens.onPrimary,
+    surfaceElevationLow = tokens.surfaceElevationLow,
+    onSurfaceElevationLow = tokens.onSurfaceElevationLow,
+    surfaceElevationMedium = tokens.surfaceElevationMedium,
+    onSurfaceElevationMedium = tokens.onSurfaceElevationMedium,
+    surfaceElevationHigh = tokens.surfaceElevationHigh,
+    onSurfaceElevationHigh = tokens.onSurfaceElevationHigh,
+    error = tokens.error,
+    onError = tokens.onError,
+    outline = tokens.outline
 )
 
 @Stable
-fun darkColorPalette(
-    primary: Color = DarkColorPaletteTokens.primary,
-    onPrimary: Color = DarkColorPaletteTokens.onPrimary,
-    surfaceElevationLow: Color = DarkColorPaletteTokens.surfaceElevationLow,
-    onSurfaceElevationLow: Color = DarkColorPaletteTokens.onSurfaceElevationLow,
-    surfaceElevationMedium: Color = DarkColorPaletteTokens.surfaceElevationMedium,
-    onSurfaceElevationMedium: Color = DarkColorPaletteTokens.onSurfaceElevationMedium,
-    surfaceElevationHigh: Color = DarkColorPaletteTokens.surfaceElevationHigh,
-    onSurfaceElevationHigh: Color = DarkColorPaletteTokens.onSurfaceElevationHigh,
-    error: Color = DarkColorPaletteTokens.error,
-    onError: Color = DarkColorPaletteTokens.onError,
-    outline: Color = DarkColorPaletteTokens.outline
-) = ColorPalette(
-    primary = primary,
-    onPrimary = onPrimary,
-    surfaceElevationLow = surfaceElevationLow,
-    onSurfaceElevationLow = onSurfaceElevationLow,
-    surfaceElevationMedium = surfaceElevationMedium,
-    onSurfaceElevationMedium = onSurfaceElevationMedium,
-    surfaceElevationHigh = surfaceElevationHigh,
-    onSurfaceElevationHigh = onSurfaceElevationHigh,
-    error = error,
-    onError = onError,
-    outline = outline
-)
+fun getThemedColorPalette(
+    darkTheme: Boolean,
+    lightThemeTokens: ColorPaletteTokens = BlueLightColorPaletteTokens,
+    darkThemeTokens: ColorPaletteTokens = BlueDarkColorPaletteTokens
+): ColorPalette {
+    return if (darkTheme) colorPalette(darkThemeTokens)
+    else colorPalette(lightThemeTokens)
+}
 
-val LocalColorPalette = compositionLocalOf { lightColorPalette() }
+val LocalColorPalette = compositionLocalOf { colorPalette(BlueLightColorPaletteTokens) }
 val LocalContentColor = compositionLocalOf { Color.Unspecified }

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/core/ui/theme/color/ColorScheme.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/core/ui/theme/color/ColorScheme.kt
@@ -22,44 +22,42 @@
  * SOFTWARE.
  */
 
-package com.stoyanvuchev.magicmessage.core.ui.theme
+package com.stoyanvuchev.magicmessage.core.ui.theme.color
 
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
-import androidx.compose.runtime.compositionLocalOf
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import com.stoyanvuchev.magicmessage.R
+import com.stoyanvuchev.magicmessage.core.ui.theme.color.tokens.BlueDarkColorPaletteTokens
+import com.stoyanvuchev.magicmessage.core.ui.theme.color.tokens.BlueLightColorPaletteTokens
+import com.stoyanvuchev.magicmessage.core.ui.theme.color.tokens.MonoDarkColorPaletteTokens
+import com.stoyanvuchev.magicmessage.core.ui.theme.color.tokens.MonoLightColorPaletteTokens
 
-enum class ThemeMode { SYSTEM, LIGHT, DARK }
-
-val LocalThemeMode = compositionLocalOf { ThemeMode.SYSTEM }
+enum class ColorScheme { MONO, BLUE }
 
 @Stable
-@Composable
-fun isInDarkThemeMode(
-    themeMode: ThemeMode = LocalThemeMode.current
-) = when (themeMode) {
-    ThemeMode.SYSTEM -> isSystemInDarkTheme()
-    ThemeMode.LIGHT -> false
-    ThemeMode.DARK -> true
+fun ColorScheme.toColorPalette(
+    darkTheme: Boolean
+): ColorPalette = when (this) {
+
+    ColorScheme.BLUE -> getThemedColorPalette(
+        darkTheme = darkTheme,
+        lightThemeTokens = BlueLightColorPaletteTokens,
+        darkThemeTokens = BlueDarkColorPaletteTokens
+    )
+
+    ColorScheme.MONO -> getThemedColorPalette(
+        darkTheme = darkTheme,
+        lightThemeTokens = MonoLightColorPaletteTokens,
+        darkThemeTokens = MonoDarkColorPaletteTokens
+    )
+
 }
 
 @Composable
-fun ThemeMode.label() = stringResource(
+fun ColorScheme.label() = stringResource(
     when (this) {
-        ThemeMode.SYSTEM -> R.string.theme_mode_system
-        ThemeMode.DARK -> R.string.theme_mode_dark
-        ThemeMode.LIGHT -> R.string.theme_mode_light
-    }
-)
-
-@Composable
-fun ThemeMode.icon() = painterResource(
-    when (this) {
-        ThemeMode.SYSTEM -> R.drawable.system_theme_mode_outlined
-        ThemeMode.DARK -> R.drawable.dark_theme_mode_outlined
-        ThemeMode.LIGHT -> R.drawable.light_theme_mode_outlined
+        ColorScheme.BLUE -> R.string.color_scheme_blue
+        ColorScheme.MONO -> R.string.color_scheme_mono
     }
 )

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/core/ui/theme/color/tokens/BlueColorPaletteTokens.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/core/ui/theme/color/tokens/BlueColorPaletteTokens.kt
@@ -22,12 +22,14 @@
  * SOFTWARE.
  */
 
-package com.stoyanvuchev.magicmessage.core.ui.theme.color
+package com.stoyanvuchev.magicmessage.core.ui.theme.color.tokens
 
-import androidx.compose.runtime.Immutable
 import androidx.compose.ui.graphics.Color
+import com.stoyanvuchev.magicmessage.core.ui.theme.color.ColorScheme
 
-object LightColorPaletteTokens : ColorPaletteTokens {
+object BlueLightColorPaletteTokens : ColorPaletteTokens {
+
+    override val scheme: ColorScheme get() = ColorScheme.BLUE
 
     override val primary: Color get() = Color(0xFF007BD1)
     override val onPrimary: Color get() = Color(0xFFFFFFFF)
@@ -48,7 +50,9 @@ object LightColorPaletteTokens : ColorPaletteTokens {
 
 }
 
-object DarkColorPaletteTokens : ColorPaletteTokens {
+object BlueDarkColorPaletteTokens : ColorPaletteTokens {
+
+    override val scheme: ColorScheme get() = ColorScheme.BLUE
 
     override val primary: Color get() = Color(0xFF007BD1)
     override val onPrimary: Color get() = Color(0xFFFFFFFF)
@@ -67,19 +71,4 @@ object DarkColorPaletteTokens : ColorPaletteTokens {
 
     override val outline: Color get() = Color(0x14FFFFFF)
 
-}
-
-@Immutable
-interface ColorPaletteTokens {
-    val primary: Color
-    val onPrimary: Color
-    val surfaceElevationLow: Color
-    val onSurfaceElevationLow: Color
-    val surfaceElevationMedium: Color
-    val onSurfaceElevationMedium: Color
-    val surfaceElevationHigh: Color
-    val onSurfaceElevationHigh: Color
-    val error: Color
-    val onError: Color
-    val outline: Color
 }

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/core/ui/theme/color/tokens/ColorPaletteTokens.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/core/ui/theme/color/tokens/ColorPaletteTokens.kt
@@ -22,44 +22,24 @@
  * SOFTWARE.
  */
 
-package com.stoyanvuchev.magicmessage.core.ui.theme
+package com.stoyanvuchev.magicmessage.core.ui.theme.color.tokens
 
-import androidx.compose.foundation.isSystemInDarkTheme
-import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
-import androidx.compose.runtime.compositionLocalOf
-import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.res.stringResource
-import com.stoyanvuchev.magicmessage.R
-
-enum class ThemeMode { SYSTEM, LIGHT, DARK }
-
-val LocalThemeMode = compositionLocalOf { ThemeMode.SYSTEM }
+import androidx.compose.ui.graphics.Color
+import com.stoyanvuchev.magicmessage.core.ui.theme.color.ColorScheme
 
 @Stable
-@Composable
-fun isInDarkThemeMode(
-    themeMode: ThemeMode = LocalThemeMode.current
-) = when (themeMode) {
-    ThemeMode.SYSTEM -> isSystemInDarkTheme()
-    ThemeMode.LIGHT -> false
-    ThemeMode.DARK -> true
+interface ColorPaletteTokens {
+    val scheme: ColorScheme
+    val primary: Color
+    val onPrimary: Color
+    val surfaceElevationLow: Color
+    val onSurfaceElevationLow: Color
+    val surfaceElevationMedium: Color
+    val onSurfaceElevationMedium: Color
+    val surfaceElevationHigh: Color
+    val onSurfaceElevationHigh: Color
+    val error: Color
+    val onError: Color
+    val outline: Color
 }
-
-@Composable
-fun ThemeMode.label() = stringResource(
-    when (this) {
-        ThemeMode.SYSTEM -> R.string.theme_mode_system
-        ThemeMode.DARK -> R.string.theme_mode_dark
-        ThemeMode.LIGHT -> R.string.theme_mode_light
-    }
-)
-
-@Composable
-fun ThemeMode.icon() = painterResource(
-    when (this) {
-        ThemeMode.SYSTEM -> R.drawable.system_theme_mode_outlined
-        ThemeMode.DARK -> R.drawable.dark_theme_mode_outlined
-        ThemeMode.LIGHT -> R.drawable.light_theme_mode_outlined
-    }
-)

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/core/ui/theme/color/tokens/MonoColorPaletteTokens.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/core/ui/theme/color/tokens/MonoColorPaletteTokens.kt
@@ -1,0 +1,74 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2025 Stoyan Vuchev
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES, OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.stoyanvuchev.magicmessage.core.ui.theme.color.tokens
+
+import androidx.compose.ui.graphics.Color
+import com.stoyanvuchev.magicmessage.core.ui.theme.color.ColorScheme
+
+object MonoLightColorPaletteTokens : ColorPaletteTokens {
+
+    override val scheme: ColorScheme get() = ColorScheme.MONO
+
+    override val primary: Color get() = Color(0xFF000000)
+    override val onPrimary: Color get() = Color(0xFFFFFFFF)
+
+    override val surfaceElevationLow: Color get() = Color(0xFFEBEBEB)
+    override val onSurfaceElevationLow: Color get() = Color(0xFF202020)
+
+    override val surfaceElevationMedium: Color get() = Color(0xFFF0F0F0)
+    override val onSurfaceElevationMedium: Color get() = Color(0xFF151515)
+
+    override val surfaceElevationHigh: Color get() = Color(0xFFFEFEFE)
+    override val onSurfaceElevationHigh: Color get() = Color(0xFF101010)
+
+    override val error: Color get() = Color(0xFFCA1F2D)
+    override val onError: Color get() = Color(0xFFFFFFFF)
+
+    override val outline: Color get() = Color(0x14000000)
+
+}
+
+object MonoDarkColorPaletteTokens : ColorPaletteTokens {
+
+    override val scheme: ColorScheme get() = ColorScheme.MONO
+
+    override val primary: Color get() = Color(0xFFFFFFFF)
+    override val onPrimary: Color get() = Color(0xFF000000)
+
+    override val surfaceElevationLow: Color get() = Color(0xFF101010)
+    override val onSurfaceElevationLow: Color get() = Color(0xFFEBEBEB)
+
+    override val surfaceElevationMedium: Color get() = Color(0xFF151515)
+    override val onSurfaceElevationMedium: Color get() = Color(0xFFF0F0F0)
+
+    override val surfaceElevationHigh: Color get() = Color(0xFF202020)
+    override val onSurfaceElevationHigh: Color get() = Color(0xFFFEFEFE)
+
+    override val error: Color get() = Color(0xFFCA1F2D)
+    override val onError: Color get() = Color(0xFFFFFFFF)
+
+    override val outline: Color get() = Color(0x14FFFFFF)
+
+}

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/data/preferences/AppPreferencesImpl.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/data/preferences/AppPreferencesImpl.kt
@@ -30,6 +30,7 @@ import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
 import com.stoyanvuchev.magicmessage.core.ui.theme.ThemeMode
+import com.stoyanvuchev.magicmessage.core.ui.theme.color.ColorScheme
 import com.stoyanvuchev.magicmessage.domain.preferences.AppPreferences
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
@@ -43,6 +44,7 @@ class AppPreferencesImpl @Inject constructor(
     companion object {
         private val IS_BOARDING_COMPLETE_KEY = booleanPreferencesKey("is_boarding_complete")
         private val THEME_MODE_KEY = stringPreferencesKey("theme_mode")
+        private val COLOR_SCHEME_KEY = stringPreferencesKey("color_scheme")
     }
 
     // Boarding
@@ -61,13 +63,28 @@ class AppPreferencesImpl @Inject constructor(
         return dataStore.data.map {
             it[THEME_MODE_KEY]?.let { mode ->
                 Json.decodeFromString<ThemeMode?>(mode)
-            } ?: ThemeMode.System
+            } ?: ThemeMode.SYSTEM
         }
     }
 
     override suspend fun setThemeMode(themeMode: ThemeMode) {
         val json = Json.encodeToString(themeMode)
         dataStore.edit { it[THEME_MODE_KEY] = json }
+    }
+
+    // Color Scheme
+
+    override fun getColorScheme(): Flow<ColorScheme> {
+        return dataStore.data.map {
+            it[COLOR_SCHEME_KEY]?.let { scheme ->
+                Json.decodeFromString<ColorScheme?>(scheme)
+            } ?: ColorScheme.MONO
+        }
+    }
+
+    override suspend fun setColorScheme(colorScheme: ColorScheme) {
+        val json = Json.encodeToString(colorScheme)
+        dataStore.edit { it[COLOR_SCHEME_KEY] = json }
     }
 
 }

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/domain/preferences/AppPreferences.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/domain/preferences/AppPreferences.kt
@@ -25,6 +25,7 @@
 package com.stoyanvuchev.magicmessage.domain.preferences
 
 import com.stoyanvuchev.magicmessage.core.ui.theme.ThemeMode
+import com.stoyanvuchev.magicmessage.core.ui.theme.color.ColorScheme
 import kotlinx.coroutines.flow.Flow
 
 interface AppPreferences {
@@ -34,5 +35,8 @@ interface AppPreferences {
 
     fun getThemeMode(): Flow<ThemeMode>
     suspend fun setThemeMode(themeMode: ThemeMode)
+
+    fun getColorScheme(): Flow<ColorScheme>
+    suspend fun setColorScheme(colorScheme: ColorScheme)
 
 }

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/MainActivity.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/MainActivity.kt
@@ -48,7 +48,8 @@ class MainActivity : ComponentActivity() {
             val state by viewModel.state.collectAsStateWithLifecycle()
 
             MagicMessageTheme(
-                themeMode = state.themeMode
+                themeMode = state.themeMode,
+                colorScheme = state.colorScheme
             ) {
 
                 AppNavHost(

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/MainActivityState.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/MainActivityState.kt
@@ -27,12 +27,14 @@ package com.stoyanvuchev.magicmessage.presentation
 import android.net.Uri
 import androidx.compose.runtime.Stable
 import com.stoyanvuchev.magicmessage.core.ui.theme.ThemeMode
+import com.stoyanvuchev.magicmessage.core.ui.theme.color.ColorScheme
 import com.stoyanvuchev.magicmessage.framework.export.ExporterState
 
 @Stable
 data class MainActivityState(
     val isBoardingComplete: Boolean? = null,
-    val themeMode: ThemeMode = ThemeMode.Dark,
+    val themeMode: ThemeMode = ThemeMode.DARK,
+    val colorScheme: ColorScheme = ColorScheme.BLUE,
     val exporterState: ExporterState = ExporterState.IDLE,
     val exporterProgress: Int = 0,
     val exportedUri: Uri? = null

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/MainActivityViewModel.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/MainActivityViewModel.kt
@@ -28,6 +28,7 @@ import android.net.Uri
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.stoyanvuchev.magicmessage.core.ui.theme.ThemeMode
+import com.stoyanvuchev.magicmessage.core.ui.theme.color.ColorScheme
 import com.stoyanvuchev.magicmessage.domain.preferences.AppPreferences
 import com.stoyanvuchev.magicmessage.framework.export.ExporterProgressObserver
 import com.stoyanvuchev.magicmessage.framework.export.ExporterState
@@ -47,6 +48,7 @@ class MainActivityViewModel @Inject constructor(
     val state = combine(
         appPreferences.getIsBoardingComplete(),
         appPreferences.getThemeMode(),
+        appPreferences.getColorScheme(),
         progressObserver.exporterState,
         progressObserver.progress,
         progressObserver.exportedUri
@@ -55,9 +57,10 @@ class MainActivityViewModel @Inject constructor(
         MainActivityState(
             isBoardingComplete = flows[0] as Boolean?,
             themeMode = flows[1] as ThemeMode,
-            exporterState = flows[2] as ExporterState,
-            exporterProgress = flows[3] as Int,
-            exportedUri = flows[4] as Uri?
+            colorScheme = flows[2] as ColorScheme,
+            exporterState = flows[3] as ExporterState,
+            exporterProgress = flows[4] as Int,
+            exportedUri = flows[5] as Uri?
         )
 
     }.stateIn(

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/main/draw_screen/DrawScreenTopBar.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/main/draw_screen/DrawScreenTopBar.kt
@@ -90,8 +90,7 @@ fun DrawScreenTopBar(
         AuraButton(
             size = 40.dp,
             onClick = { onUIAction(DrawScreenUIAction.Export(messageId = state.messageId)) },
-            isGlowVisible = isGlowVisible,
-            glowColor = state.drawConfiguration.color
+            isGlowVisible = isGlowVisible
         ) {
 
             Icon(

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/main/home_screen/HomeScreen.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/main/home_screen/HomeScreen.kt
@@ -136,7 +136,7 @@ fun HomeScreen(
                 ) {
 
                     Icon(
-                        modifier = Modifier.size(24.dp),
+                        modifier = Modifier.size(26.dp),
                         painter = painterResource(R.drawable.pencil_icon),
                         contentDescription = null
                     )

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/main/menu_screen/MenuScreen.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/main/menu_screen/MenuScreen.kt
@@ -30,8 +30,14 @@ import androidx.compose.animation.ExperimentalSharedTransitionApi
 import androidx.compose.animation.SharedTransitionLayout
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Scaffold
@@ -45,6 +51,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
 import com.stoyanvuchev.magicmessage.R
 import com.stoyanvuchev.magicmessage.core.ui.components.EmptyBottomSpacer
 import com.stoyanvuchev.magicmessage.core.ui.components.RowSelectionItem
@@ -55,7 +62,12 @@ import com.stoyanvuchev.magicmessage.core.ui.event.NavigationEvent
 import com.stoyanvuchev.magicmessage.core.ui.theme.LocalThemeMode
 import com.stoyanvuchev.magicmessage.core.ui.theme.Theme
 import com.stoyanvuchev.magicmessage.core.ui.theme.ThemeMode
+import com.stoyanvuchev.magicmessage.core.ui.theme.color.ColorScheme
+import com.stoyanvuchev.magicmessage.core.ui.theme.color.LocalColorPalette
+import com.stoyanvuchev.magicmessage.core.ui.theme.color.label
+import com.stoyanvuchev.magicmessage.core.ui.theme.color.toColorPalette
 import com.stoyanvuchev.magicmessage.core.ui.theme.icon
+import com.stoyanvuchev.magicmessage.core.ui.theme.isInDarkThemeMode
 import com.stoyanvuchev.magicmessage.core.ui.theme.label
 import com.stoyanvuchev.magicmessage.core.ui.transition.defaultBoundsTransformation
 
@@ -148,16 +160,21 @@ fun MenuScreen(
 
             val label by rememberUpdatedState(
                 when (sharedKey) {
+
                     "theme_mode" -> {
                         stringResource(R.string.theme_mode) +
                                 ": " + LocalThemeMode.current.label()
                     }
+
                     "color_scheme" -> {
-                        stringResource(R.string.color_scheme)
+                        stringResource(R.string.color_scheme) +
+                                ": " + LocalColorPalette.current.scheme.label()
                     }
+
                     "trash" -> stringResource(R.string.trash_label)
                     "about" -> stringResource(R.string.about_label)
                     else -> stringResource(R.string.app_name)
+
                 }
             )
 
@@ -212,19 +229,45 @@ fun MenuScreen(
 
                     "color_scheme" -> {
 
-                        RowSelectionItem(
-                            onClick = remember { {} },
-                            selected = true,
-                            label = { Text(text = "Default") },
-                            icon = {
+                        ColorScheme.entries.forEach { colorScheme ->
 
-                                Icon(
-                                    painter = painterResource(R.drawable.color_scheme_default_outlined),
-                                    contentDescription = null
-                                )
+                            val darkTheme = isInDarkThemeMode()
+                            val color by rememberUpdatedState(
+                                colorScheme.toColorPalette(darkTheme).primary
+                            )
 
-                            }
-                        )
+                            RowSelectionItem(
+                                onClick = remember {
+                                    {
+                                        onUIAction(
+                                            MenuScreenUIAction.SetColorScheme(colorScheme)
+                                        )
+                                    }
+                                },
+                                selected = colorScheme == LocalColorPalette.current.scheme,
+                                label = { Text(text = colorScheme.label()) },
+                                icon = {
+
+                                    Box(
+                                        modifier = Modifier
+                                            .size(24.dp)
+                                            .border(
+                                                width = 1.dp,
+                                                color = Theme.colors.onSurfaceElevationLow
+                                                    .copy(.5f),
+                                                shape = CircleShape
+                                            )
+                                            .padding(3.dp)
+                                            .background(
+                                                color = color,
+                                                shape = CircleShape
+                                            )
+                                    )
+
+                                }
+                            )
+
+                        }
 
                     }
 

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/main/menu_screen/MenuScreenPersonalizationSection.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/main/menu_screen/MenuScreenPersonalizationSection.kt
@@ -45,6 +45,8 @@ import com.stoyanvuchev.magicmessage.core.ui.components.list.ListOptionItem
 import com.stoyanvuchev.magicmessage.core.ui.components.list.listOfOptionItemsSelection
 import com.stoyanvuchev.magicmessage.core.ui.etc.UIString
 import com.stoyanvuchev.magicmessage.core.ui.theme.LocalThemeMode
+import com.stoyanvuchev.magicmessage.core.ui.theme.color.LocalColorPalette
+import com.stoyanvuchev.magicmessage.core.ui.theme.color.label
 import com.stoyanvuchev.magicmessage.core.ui.theme.icon
 import com.stoyanvuchev.magicmessage.core.ui.theme.label
 
@@ -126,7 +128,8 @@ fun LazyListScope.menuScreenPersonalizationSection(
         item(key = "${categoryKey}_color_scheme") {
 
             val colorSchemeKey = remember { "color_scheme" }
-            val onSharedKeyLambda = remember { { /*TODO*/ } }
+            val onSharedKeyLambda = remember { { onSharedKey(colorSchemeKey) } }
+            val scheme = LocalColorPalette.current.scheme
 
             AnimatedVisibility(
                 modifier = Modifier
@@ -158,7 +161,7 @@ fun LazyListScope.menuScreenPersonalizationSection(
                                     animatedVisibilityScope = this@AnimatedVisibility,
                                     boundsTransform = boundsTransform,
                                 ),
-                                text = stringResource(R.string.color_scheme)
+                                text = stringResource(R.string.color_scheme) + ": " + scheme.label()
                             )
 
                         },

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/main/menu_screen/MenuScreenUIAction.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/main/menu_screen/MenuScreenUIAction.kt
@@ -26,12 +26,17 @@ package com.stoyanvuchev.magicmessage.presentation.main.menu_screen
 
 import androidx.compose.runtime.Stable
 import com.stoyanvuchev.magicmessage.core.ui.theme.ThemeMode
+import com.stoyanvuchev.magicmessage.core.ui.theme.color.ColorScheme
 
 @Stable
 sealed interface MenuScreenUIAction {
 
     data class SetThemeMode(
         val themeMode: ThemeMode
+    ) : MenuScreenUIAction
+
+    data class SetColorScheme(
+        val colorScheme: ColorScheme
     ) : MenuScreenUIAction
 
 }

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/main/menu_screen/MenuScreenViewModel.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/main/menu_screen/MenuScreenViewModel.kt
@@ -47,6 +47,7 @@ class MenuScreenViewModel @Inject constructor(
     fun onUIAction(action: MenuScreenUIAction) {
         when (action) {
             is MenuScreenUIAction.SetThemeMode -> setThemeMode(action)
+            is MenuScreenUIAction.SetColorScheme -> setColorScheme(action)
         }
     }
 
@@ -58,6 +59,14 @@ class MenuScreenViewModel @Inject constructor(
         viewModelScope.launch {
             withContext(Dispatchers.IO) {
                 appPreferences.setThemeMode(action.themeMode)
+            }
+        }
+    }
+
+    private fun setColorScheme(action: MenuScreenUIAction.SetColorScheme) {
+        viewModelScope.launch {
+            withContext(Dispatchers.IO) {
+                appPreferences.setColorScheme(action.colorScheme)
             }
         }
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -74,4 +74,6 @@
     <string name="permission_screen_notifications_label">Notifications</string>
     <string name="permission_screen_request_permission">Request Permissions</string>
     <string name="permission_screen_change_settings">Change Settings</string>
+    <string name="color_scheme_blue">Blue</string>
+    <string name="color_scheme_mono">Mono</string>
 </resources>


### PR DESCRIPTION
This commit introduces the ability for users to select different color schemes for the application, enhancing personalization.

**Key Changes:**

- **`ColorScheme` Enum & Integration:**
    - Created `ColorScheme.kt` enum with `MONO` and `BLUE` options.
    - Added `toColorPalette()` extension function to map `ColorScheme` to `ColorPalette`.
    - Integrated `ColorScheme` into `AppPreferences` for persistence.
    - `MainActivityViewModel` now collects and provides `ColorScheme` to `MainActivityState`.
    - `MainActivity` applies the selected `ColorScheme` to `MagicMessageTheme`.
    - `UIWrapper` now uses `getThemedColorPalette` which accepts a `ColorScheme`.

- **`ColorPaletteTokens` Refactor:**
    - Renamed `ColorPaletteTokens.kt` to `core.ui.theme.color.tokens.ColorPaletteTokens.kt`.
    - Created `BlueColorPaletteTokens.kt` and `MonoColorPaletteTokens.kt` implementing `ColorPaletteTokens` for both light and dark themes.
    - `ColorPaletteTokens` interface now includes a `scheme: ColorScheme` property.
    - `ColorPalette` data class now includes a `scheme: ColorScheme` property.
    - `AnimatedColorPalette` now includes `scheme`.
    - Refactored `getThemedColorPalette` to select tokens based on the current theme and `ColorScheme`.

- **Menu Screen UI:**
    - `MenuScreen` now displays options to select `ColorScheme`. - Each option shows a colored circle representing the primary color of the scheme.
    - `MenuScreenViewModel` handles `SetColorScheme` UI action to update `AppPreferences`.
    - `MenuScreenPersonalizationSection` updates to display the current `ColorScheme` label.

- **`AppPreferences` Update:**
    - Added `COLOR_SCHEME_KEY` to `AppPreferencesImpl`.
    - Implemented `getColorScheme()` and `setColorScheme()` in `AppPreferencesImpl` to store and retrieve the selected `ColorScheme`.

- **`AuraButton` Enhancement:**
    - `AuraButton` now animates `containerColor` and `contentColor` based on `isGlowVisible`.
    - Added `inactiveColor` and `onInactiveColor` parameters.
    - Removed `glowColor` parameter from `DrawScreenTopBar` usage as it's now handled internally by `AuraButton` based on the theme's primary color.

- **Minor UI Adjustments:**
    - Increased icon size in `HomeScreen` from 24.dp to 26.dp.
    - Updated string resources for color scheme labels (`color_scheme_blue`, `color_scheme_mono`).
    - Changed default `ThemeMode` in `MainActivityState` to `ThemeMode.DARK`.
    - Changed default `ThemeMode` in `LocalThemeMode` and `UIWrapper` to `ThemeMode.SYSTEM`.