### PR TITLE
Implemented dynamic color theming.

### DIFF
--- a/app/src/main/java/com/stoyanvuchev/magicmessage/core/ui/theme/color/ColorPalette.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/core/ui/theme/color/ColorPalette.kt
@@ -24,12 +24,18 @@
 
 package com.stoyanvuchev.magicmessage.core.ui.theme.color
 
+import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.compositeOver
+import androidx.compose.ui.res.colorResource
 import com.stoyanvuchev.magicmessage.core.ui.theme.color.tokens.BlueDarkColorPaletteTokens
 import com.stoyanvuchev.magicmessage.core.ui.theme.color.tokens.BlueLightColorPaletteTokens
 import com.stoyanvuchev.magicmessage.core.ui.theme.color.tokens.ColorPaletteTokens
+import com.stoyanvuchev.magicmessage.core.ui.theme.color.tokens.MonoDarkColorPaletteTokens
+import com.stoyanvuchev.magicmessage.core.ui.theme.color.tokens.MonoLightColorPaletteTokens
 
 @Stable
 data class ColorPalette(
@@ -73,6 +79,41 @@ fun getThemedColorPalette(
 ): ColorPalette {
     return if (darkTheme) colorPalette(darkThemeTokens)
     else colorPalette(lightThemeTokens)
+}
+
+@Stable
+@Composable
+fun getDynamicColorPalette(
+    darkTheme: Boolean
+): ColorPalette {
+
+    val primary = colorResource(android.R.color.system_accent1_500)
+    val primaryComposite = remember(primary) { primary.copy(alpha = .04f) }
+    val onPrimary = remember { Color.White }
+    val tokens = remember(darkTheme) {
+        if (darkTheme) MonoDarkColorPaletteTokens
+        else MonoLightColorPaletteTokens
+    }
+
+    val surfaceLow = primaryComposite.compositeOver(tokens.surfaceElevationLow)
+    val surfaceMedium = primaryComposite.compositeOver(tokens.surfaceElevationMedium)
+    val surfaceHigh = primaryComposite.compositeOver(tokens.surfaceElevationHigh)
+
+    return ColorPalette(
+        scheme = ColorScheme.DYNAMIC,
+        primary = primary,
+        onPrimary = onPrimary,
+        surfaceElevationLow = surfaceLow,
+        onSurfaceElevationLow = tokens.onSurfaceElevationLow,
+        surfaceElevationMedium = surfaceMedium,
+        onSurfaceElevationMedium = tokens.onSurfaceElevationMedium,
+        surfaceElevationHigh = surfaceHigh,
+        onSurfaceElevationHigh = tokens.onSurfaceElevationHigh,
+        error = tokens.error,
+        onError = tokens.onError,
+        outline = tokens.outline
+    )
+
 }
 
 val LocalColorPalette = compositionLocalOf { colorPalette(BlueLightColorPaletteTokens) }

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/core/ui/theme/color/ColorScheme.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/core/ui/theme/color/ColorScheme.kt
@@ -33,9 +33,10 @@ import com.stoyanvuchev.magicmessage.core.ui.theme.color.tokens.BlueLightColorPa
 import com.stoyanvuchev.magicmessage.core.ui.theme.color.tokens.MonoDarkColorPaletteTokens
 import com.stoyanvuchev.magicmessage.core.ui.theme.color.tokens.MonoLightColorPaletteTokens
 
-enum class ColorScheme { MONO, BLUE }
+enum class ColorScheme { MONO, BLUE, DYNAMIC }
 
 @Stable
+@Composable
 fun ColorScheme.toColorPalette(
     darkTheme: Boolean
 ): ColorPalette = when (this) {
@@ -52,6 +53,8 @@ fun ColorScheme.toColorPalette(
         darkThemeTokens = MonoDarkColorPaletteTokens
     )
 
+    ColorScheme.DYNAMIC -> getDynamicColorPalette(darkTheme)
+
 }
 
 @Composable
@@ -59,5 +62,6 @@ fun ColorScheme.label() = stringResource(
     when (this) {
         ColorScheme.BLUE -> R.string.color_scheme_blue
         ColorScheme.MONO -> R.string.color_scheme_mono
+        ColorScheme.DYNAMIC -> R.string.color_scheme_dynamic
     }
 )

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/data/preferences/AppPreferencesImpl.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/data/preferences/AppPreferencesImpl.kt
@@ -78,7 +78,7 @@ class AppPreferencesImpl @Inject constructor(
         return dataStore.data.map {
             it[COLOR_SCHEME_KEY]?.let { scheme ->
                 Json.decodeFromString<ColorScheme?>(scheme)
-            } ?: ColorScheme.MONO
+            } ?: ColorScheme.DYNAMIC
         }
     }
 

--- a/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/MainActivityState.kt
+++ b/app/src/main/java/com/stoyanvuchev/magicmessage/presentation/MainActivityState.kt
@@ -33,7 +33,7 @@ import com.stoyanvuchev.magicmessage.framework.export.ExporterState
 @Stable
 data class MainActivityState(
     val isBoardingComplete: Boolean? = null,
-    val themeMode: ThemeMode = ThemeMode.DARK,
+    val themeMode: ThemeMode = ThemeMode.SYSTEM,
     val colorScheme: ColorScheme = ColorScheme.BLUE,
     val exporterState: ExporterState = ExporterState.IDLE,
     val exporterProgress: Int = 0,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -76,4 +76,5 @@
     <string name="permission_screen_change_settings">Change Settings</string>
     <string name="color_scheme_blue">Blue</string>
     <string name="color_scheme_mono">Mono</string>
+    <string name="color_scheme_dynamic">Dynamic</string>
 </resources>


### PR DESCRIPTION
This commit introduces a dynamic color scheme option, allowing the app's theme to adapt to the user's system accent color.

**Key Changes:**

- **`ColorScheme.kt`:**
    - Added `DYNAMIC` to the `ColorScheme` enum.
    - Updated `toColorPalette()` to handle the new `DYNAMIC` scheme by calling `getDynamicColorPalette()`.
    - Added a string resource mapping for "Dynamic" in `toStringResource()`.

- **`ColorPalette.kt`:**
    - Created a new composable function `getDynamicColorPalette()`: - Retrieves the system accent color using `colorResource(android.R.color.system_accent1_500)`. - Calculates composite surface colors based on the primary accent color and existing Mono theme tokens. - Returns a `ColorPalette` instance with the `DYNAMIC` scheme and derived colors.

- **`AppPreferencesImpl.kt`:**
    - Changed the default `colorScheme` in `observeColorScheme()` from `ColorScheme.MONO` to `ColorScheme.DYNAMIC`.

- **`MainActivityState.kt`:**
    - Updated the default `themeMode` from `ThemeMode.DARK` to `ThemeMode.SYSTEM`.

- **`strings.xml`:**
    - Added a new string resource `color_scheme_dynamic` with the value "Dynamic".